### PR TITLE
override default CORS handler for httprouter

### DIFF
--- a/cmd/semaphore/config/arguments.go
+++ b/cmd/semaphore/config/arguments.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"log"
-
 	"github.com/jexia/semaphore"
 	"github.com/jexia/semaphore/cmd/semaphore/middleware"
 	"github.com/jexia/semaphore/pkg/broker"
@@ -61,12 +59,6 @@ func ConstructArguments(params *Semaphore) ([]config.Option, error) {
 		arguments = append(arguments, semaphore.WithSchema(protobuffers.SchemaResolver(params.Protobuffers, path)))
 		arguments = append(arguments, semaphore.WithServices(protobuffers.ServiceResolver(params.Protobuffers, path)))
 	}
-
-	log.Println()
-	log.Println()
-	log.Println(params.HTTP)
-	log.Println()
-	log.Println()
 
 	if params.HTTP.Address != "" {
 		arguments = append(

--- a/cmd/semaphore/config/arguments.go
+++ b/cmd/semaphore/config/arguments.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"log"
+
 	"github.com/jexia/semaphore"
 	"github.com/jexia/semaphore/cmd/semaphore/middleware"
 	"github.com/jexia/semaphore/pkg/broker"
@@ -60,8 +62,26 @@ func ConstructArguments(params *Semaphore) ([]config.Option, error) {
 		arguments = append(arguments, semaphore.WithServices(protobuffers.ServiceResolver(params.Protobuffers, path)))
 	}
 
+	log.Println()
+	log.Println()
+	log.Println(params.HTTP)
+	log.Println()
+	log.Println()
+
 	if params.HTTP.Address != "" {
-		arguments = append(arguments, semaphore.WithListener(http.NewListener(params.HTTP.Address, params.HTTP.Origin, specs.Options{})))
+		arguments = append(
+			arguments,
+			semaphore.WithListener(
+				http.NewListener(
+					params.HTTP.Address,
+					http.WithOrigins(params.HTTP.Origin),
+					http.WithReadTimeout(params.HTTP.ReadTimeout),
+					http.WithWriteTimeout(params.HTTP.WriteTimeout),
+					http.WithKeyFile(params.HTTP.KeyFile),
+					http.WithCertFile(params.HTTP.CertFile),
+				),
+			),
+		)
 	}
 
 	if params.GraphQL.Address != "" {

--- a/cmd/semaphore/config/arguments.go
+++ b/cmd/semaphore/config/arguments.go
@@ -61,7 +61,7 @@ func ConstructArguments(params *Semaphore) ([]config.Option, error) {
 	}
 
 	if params.HTTP.Address != "" {
-		arguments = append(arguments, semaphore.WithListener(http.NewListener(params.HTTP.Address, specs.Options{})))
+		arguments = append(arguments, semaphore.WithListener(http.NewListener(params.HTTP.Address, params.HTTP.Origin, specs.Options{})))
 	}
 
 	if params.GraphQL.Address != "" {

--- a/cmd/semaphore/config/config.go
+++ b/cmd/semaphore/config/config.go
@@ -26,22 +26,15 @@ func Parse(options *hcl.Options, target *Semaphore) {
 	}
 
 	if options.GraphQL != nil && target.GraphQL.Address == "" {
-		target.GraphQL = GraphQL{
-			Address: options.GraphQL.Address,
-		}
+		target.GraphQL = GraphQL(*options.GraphQL)
 	}
 
 	if options.HTTP != nil && target.HTTP.Address == "" {
-		target.HTTP = HTTP{
-			Address: options.HTTP.Address,
-			Origin:  options.HTTP.Origin,
-		}
+		target.HTTP = HTTP(*options.HTTP)
 	}
 
 	if options.GRPC != nil && target.GRPC.Address == "" {
-		target.GRPC = GRPC{
-			Address: options.GRPC.Address,
-		}
+		target.GRPC = GRPC(*options.GRPC)
 	}
 
 	if options.Prometheus != nil && target.Prometheus.Address == "" {
@@ -69,8 +62,12 @@ type Prometheus struct {
 
 // HTTP configurations
 type HTTP struct {
-	Address string
-	Origin  []string
+	Address      string
+	Origin       []string
+	CertFile     string
+	KeyFile      string
+	ReadTimeout  string
+	WriteTimeout string
 }
 
 // GRPC configurations

--- a/cmd/semaphore/config/config.go
+++ b/cmd/semaphore/config/config.go
@@ -34,6 +34,7 @@ func Parse(options *hcl.Options, target *Semaphore) {
 	if options.HTTP != nil && target.HTTP.Address == "" {
 		target.HTTP = HTTP{
 			Address: options.HTTP.Address,
+			Origin:  options.HTTP.Origin,
 		}
 	}
 
@@ -69,6 +70,7 @@ type Prometheus struct {
 // HTTP configurations
 type HTTP struct {
 	Address string
+	Origin  []string
 }
 
 // GRPC configurations

--- a/examples/custom-functions/main.go
+++ b/examples/custom-functions/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	client, err := semaphore.New(
 		semaphore.WithLogLevel("*", "debug"),
-		semaphore.WithListener(http.NewListener(":8080", specs.Options{})),
+		semaphore.WithListener(http.NewListener(":8080", nil, specs.Options{})),
 		semaphore.WithFlows(hcl.FlowsResolver("./*.hcl")),
 		semaphore.WithEndpoints(hcl.EndpointsResolver("./*.hcl")),
 		semaphore.WithSchema(protobuffers.SchemaResolver([]string{"./proto"}, "./proto/*.proto")),

--- a/examples/custom-functions/main.go
+++ b/examples/custom-functions/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	client, err := semaphore.New(
 		semaphore.WithLogLevel("*", "debug"),
-		semaphore.WithListener(http.NewListener(":8080", nil, specs.Options{})),
+		semaphore.WithListener(http.NewListener(":8080")),
 		semaphore.WithFlows(hcl.FlowsResolver("./*.hcl")),
 		semaphore.WithEndpoints(hcl.EndpointsResolver("./*.hcl")),
 		semaphore.WithSchema(protobuffers.SchemaResolver([]string{"./proto"}, "./proto/*.proto")),

--- a/examples/http/config.hcl
+++ b/examples/http/config.hcl
@@ -5,7 +5,6 @@ include = ["flow.hcl"]
 
 http {
     address = ":8080"
-    origin = ["http://test.com","http://example.com"]
 }
 
 services {

--- a/examples/http/config.hcl
+++ b/examples/http/config.hcl
@@ -5,6 +5,7 @@ include = ["flow.hcl"]
 
 http {
     address = ":8080"
+    origin = ["http://test.com","http://example.com"]
 }
 
 services {

--- a/examples/http/flow.hcl
+++ b/examples/http/flow.hcl
@@ -5,7 +5,9 @@ endpoint "FetchLatestProject" "http" {
 }
 
 flow "FetchLatestProject" {
-	input "com.semaphore.Query" {}
+	input "com.semaphore.Query" {
+		header = ["Authorization", "Timestamp"]
+	}
 
 	resource "query" {
 		request "com.semaphore.Todo" "Get" {

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/micro/go-micro/v2 v2.3.0
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.2.1
+	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/zclconf/go-cty v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -435,6 +435,8 @@ github.com/rainycape/memcache v0.0.0-20150622160815-1031fa0ce2f2/go.mod h1:7tZKc
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
+github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=

--- a/main_test.go
+++ b/main_test.go
@@ -70,7 +70,7 @@ func TestNewClient(t *testing.T) {
 				WithServices(hcl.ServicesResolver(file.Path)),
 				WithSchema(mock.SchemaResolver(schema)),
 				WithCodec(json.NewConstructor()),
-				WithListener(http.NewListener(":0", nil, nil)),
+				WithListener(http.NewListener(":0")),
 				WithCaller(http.NewCaller()),
 				WithLogLevel("*", "debug"),
 			)
@@ -162,7 +162,7 @@ func TestServe(t *testing.T) {
 				WithServices(hcl.ServicesResolver(file.Path)),
 				WithSchema(mock.SchemaResolver(schema)),
 				WithCodec(json.NewConstructor()),
-				WithListener(http.NewListener(":0", nil, nil)),
+				WithListener(http.NewListener(":0")),
 				WithCaller(http.NewCaller()),
 				WithLogLevel("*", "debug"),
 			)
@@ -215,7 +215,7 @@ func TestErrServe(t *testing.T) {
 				WithServices(hcl.ServicesResolver(file.Path)),
 				WithSchema(mock.SchemaResolver(schema)),
 				WithCodec(json.NewConstructor()),
-				WithListener(http.NewListener(listener.Addr().String(), nil, nil)),
+				WithListener(http.NewListener(listener.Addr().String())),
 				WithCaller(http.NewCaller()),
 				WithLogLevel("*", "debug"),
 			)

--- a/main_test.go
+++ b/main_test.go
@@ -70,7 +70,7 @@ func TestNewClient(t *testing.T) {
 				WithServices(hcl.ServicesResolver(file.Path)),
 				WithSchema(mock.SchemaResolver(schema)),
 				WithCodec(json.NewConstructor()),
-				WithListener(http.NewListener(":0", nil)),
+				WithListener(http.NewListener(":0", nil, nil)),
 				WithCaller(http.NewCaller()),
 				WithLogLevel("*", "debug"),
 			)
@@ -162,7 +162,7 @@ func TestServe(t *testing.T) {
 				WithServices(hcl.ServicesResolver(file.Path)),
 				WithSchema(mock.SchemaResolver(schema)),
 				WithCodec(json.NewConstructor()),
-				WithListener(http.NewListener(":0", nil)),
+				WithListener(http.NewListener(":0", nil, nil)),
 				WithCaller(http.NewCaller()),
 				WithLogLevel("*", "debug"),
 			)
@@ -215,7 +215,7 @@ func TestErrServe(t *testing.T) {
 				WithServices(hcl.ServicesResolver(file.Path)),
 				WithSchema(mock.SchemaResolver(schema)),
 				WithCodec(json.NewConstructor()),
-				WithListener(http.NewListener(listener.Addr().String(), nil)),
+				WithListener(http.NewListener(listener.Addr().String(), nil, nil)),
 				WithCaller(http.NewCaller()),
 				WithLogLevel("*", "debug"),
 			)

--- a/pkg/providers/hcl/intermediate.go
+++ b/pkg/providers/hcl/intermediate.go
@@ -28,8 +28,12 @@ type GraphQL struct {
 
 // HTTP represent the HTTP option definitions
 type HTTP struct {
-	Address string   `hcl:"address"`
-	Origin  []string `hcl:"origin,optional"`
+	Address      string   `hcl:"address"`
+	Origin       []string `hcl:"origin,optional"`
+	CertFile     string   `hcl:"cert_file,optional"`
+	KeyFile      string   `hcl:"key_file,optional"`
+	ReadTimeout  string   `hcl:"read_timeout,optional"`
+	WriteTimeout string   `hcl:"write_timeout,optional"`
 }
 
 // GRPC represent the gRPC option definitions

--- a/pkg/providers/hcl/intermediate.go
+++ b/pkg/providers/hcl/intermediate.go
@@ -28,7 +28,8 @@ type GraphQL struct {
 
 // HTTP represent the HTTP option definitions
 type HTTP struct {
-	Address string `hcl:"address"`
+	Address string   `hcl:"address"`
+	Origin  []string `hcl:"origin,optional"`
 }
 
 // GRPC represent the gRPC option definitions

--- a/pkg/providers/openapi3/openapi_test.go
+++ b/pkg/providers/openapi3/openapi_test.go
@@ -49,7 +49,7 @@ func TestOpenAPI3Generation(t *testing.T) {
 				semaphore.WithServices(hcl.ServicesResolver(file.Path)),
 				semaphore.WithEndpoints(hcl.EndpointsResolver(file.Path)),
 				semaphore.WithCodec(json.NewConstructor()),
-				semaphore.WithListener(http.NewListener(":0", nil)),
+				semaphore.WithListener(http.NewListener(":0", nil, nil)),
 				semaphore.WithListener(grpc.NewListener(":0", nil)),
 				semaphore.WithCaller(http.NewCaller()),
 			}

--- a/pkg/providers/openapi3/openapi_test.go
+++ b/pkg/providers/openapi3/openapi_test.go
@@ -49,7 +49,7 @@ func TestOpenAPI3Generation(t *testing.T) {
 				semaphore.WithServices(hcl.ServicesResolver(file.Path)),
 				semaphore.WithEndpoints(hcl.EndpointsResolver(file.Path)),
 				semaphore.WithCodec(json.NewConstructor()),
-				semaphore.WithListener(http.NewListener(":0", nil, nil)),
+				semaphore.WithListener(http.NewListener(":0")),
 				semaphore.WithListener(grpc.NewListener(":0", nil)),
 				semaphore.WithCaller(http.NewCaller()),
 			}

--- a/pkg/transport/http/http_test.go
+++ b/pkg/transport/http/http_test.go
@@ -49,18 +49,8 @@ func NewCallerFunc(fn func(context.Context, references.Store) error) flow.Call {
 func NewSimpleMockSpecs() *specs.ParameterMap {
 	return &specs.ParameterMap{
 		Header: specs.Header{
-			"Authorization": &specs.Property{
-				Name:  "Authorization",
-				Path:  "authorization",
-				Type:  "string",
-				Label: "optional",
-			},
-			"Timestamp": &specs.Property{
-				Name:  "Timestamp",
-				Path:  "timestamp",
-				Type:  "string",
-				Label: "optional",
-			},
+			"Authorization": &specs.Property{},
+			"Timestamp":     &specs.Property{},
 		},
 		Property: &specs.Property{
 			Type:  types.Message,

--- a/pkg/transport/http/http_test.go
+++ b/pkg/transport/http/http_test.go
@@ -48,6 +48,20 @@ func NewCallerFunc(fn func(context.Context, references.Store) error) flow.Call {
 
 func NewSimpleMockSpecs() *specs.ParameterMap {
 	return &specs.ParameterMap{
+		Header: specs.Header{
+			"Authorization": &specs.Property{
+				Name:  "Authorization",
+				Path:  "authorization",
+				Type:  "string",
+				Label: "optional",
+			},
+			"Timestamp": &specs.Property{
+				Name:  "Timestamp",
+				Path:  "timestamp",
+				Type:  "string",
+				Label: "optional",
+			},
+		},
 		Property: &specs.Property{
 			Type:  types.Message,
 			Label: labels.Optional,

--- a/pkg/transport/http/listener_options.go
+++ b/pkg/transport/http/listener_options.go
@@ -53,7 +53,7 @@ func WithReadTimeout(timeout string) ListenerOption {
 
 		duration, err := time.ParseDuration(timeout)
 		if err != nil {
-			return fmt.Errorf("invalid input for read timeout: %w", err)
+			return fmt.Errorf("invalid duration for read timeout: %q", timeout)
 		}
 
 		options.readTimeout = duration
@@ -71,7 +71,7 @@ func WithWriteTimeout(timeout string) ListenerOption {
 
 		duration, err := time.ParseDuration(timeout)
 		if err != nil {
-			return fmt.Errorf("invalid input for write timeout: %w", err)
+			return fmt.Errorf("invalid duration for write timeout: %q", timeout)
 		}
 
 		options.writeTimeout = duration
@@ -89,7 +89,7 @@ func WithKeyFile(path string) ListenerOption {
 
 		info, err := os.Stat(path)
 		if err != nil {
-			return fmt.Errorf("cannot open key file: %w", err)
+			return fmt.Errorf("cannot open key file: %q", path)
 		}
 
 		if info.IsDir() {
@@ -111,7 +111,7 @@ func WithCertFile(path string) ListenerOption {
 
 		info, err := os.Stat(path)
 		if err != nil {
-			return fmt.Errorf("cannot open certificate file: %w", err)
+			return fmt.Errorf("cannot open certificate file: %q", path)
 		}
 
 		if info.IsDir() {

--- a/pkg/transport/http/listener_options.go
+++ b/pkg/transport/http/listener_options.go
@@ -1,0 +1,134 @@
+package http
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+const (
+	defaultReadTimeout  = 5 * time.Second
+	defaultWriteTimeout = 5 * time.Second
+)
+
+// ListenerOption defines a single listener option
+type ListenerOption func(*ListenerOptions) error
+
+// ListenerOptions represents the available HTTP options
+type ListenerOptions struct {
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+	certFile     string
+	keyFile      string
+	origins      []string
+}
+
+// DefaultListenerOptions returns default listener configuration
+func DefaultListenerOptions() *ListenerOptions {
+	return &ListenerOptions{
+		readTimeout:  defaultReadTimeout,
+		writeTimeout: defaultWriteTimeout,
+	}
+}
+
+// NewListenerOptions creates listener config with provided options
+func NewListenerOptions(options ...ListenerOption) (*ListenerOptions, error) {
+	o := DefaultListenerOptions()
+
+	for _, option := range options {
+		if err := option(o); err != nil {
+			return nil, err
+		}
+	}
+
+	return o, nil
+}
+
+// WithReadTimeout overrides the default read timeout
+func WithReadTimeout(timeout string) ListenerOption {
+	return func(options *ListenerOptions) error {
+		if timeout == "" {
+			return nil
+		}
+
+		duration, err := time.ParseDuration(timeout)
+		if err != nil {
+			return fmt.Errorf("invalid input for read timeout: %w", err)
+		}
+
+		options.readTimeout = duration
+
+		return nil
+	}
+}
+
+// WithWriteTimeout overrides default write timeout
+func WithWriteTimeout(timeout string) ListenerOption {
+	return func(options *ListenerOptions) error {
+		if timeout == "" {
+			return nil
+		}
+
+		duration, err := time.ParseDuration(timeout)
+		if err != nil {
+			return fmt.Errorf("invalid input for write timeout: %w", err)
+		}
+
+		options.writeTimeout = duration
+
+		return nil
+	}
+}
+
+// WithKeyFile defines key file
+func WithKeyFile(path string) ListenerOption {
+	return func(options *ListenerOptions) error {
+		if path == "" {
+			return nil
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("cannot open key file: %w", err)
+		}
+
+		if info.IsDir() {
+			return fmt.Errorf("%q is not a file", path)
+		}
+
+		options.keyFile = path
+
+		return nil
+	}
+}
+
+// WithCertFile defines certificate file
+func WithCertFile(path string) ListenerOption {
+	return func(options *ListenerOptions) error {
+		if path == "" {
+			return nil
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("cannot open certificate file: %w", err)
+		}
+
+		if info.IsDir() {
+			return fmt.Errorf("%q is not a file", path)
+		}
+
+		options.certFile = path
+
+		return nil
+	}
+}
+
+// WithOrigins sets allowed origins for incoming preflight requests
+func WithOrigins(list []string) ListenerOption {
+	return func(options *ListenerOptions) error {
+		options.origins = list
+
+		return nil
+	}
+}

--- a/pkg/transport/http/listener_options_test.go
+++ b/pkg/transport/http/listener_options_test.go
@@ -1,22 +1,89 @@
 package http
 
-// func TestParseListenerOptions(t *testing.T) {
-// 	duration := time.Second
-// 	options := specs.Options{
-// 		ReadTimeoutOption:  duration.String(),
-// 		WriteTimeoutOption: duration.String(),
-// 	}
-//
-// 	result, err := ParseListenerOptions(options)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-//
-// 	if result.ReadTimeout != duration {
-// 		t.Fatalf("unexpected read timeout %+v, expected %+v", result.ReadTimeout, duration)
-// 	}
-//
-// 	if result.WriteTimeout != duration {
-// 		t.Fatalf("unexpected write timeout %+v, expected %+v", result.ReadTimeout, duration)
-// 	}
-// }
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func Test_NewListenerOptions(t *testing.T) {
+	type test struct {
+		options  []ListenerOption
+		error    error
+		expected *ListenerOptions
+	}
+
+	tests := map[string]test{
+		"check if error is returnes when unable to parse read timeout": {
+			options: []ListenerOption{
+				WithReadTimeout("one second"),
+			},
+			error: fmt.Errorf(`invalid duration for read timeout: "one second"`),
+		},
+		"check if error is returnes when unable to parse write timeout": {
+			options: []ListenerOption{
+				WithWriteTimeout("one minute"),
+			},
+			error: fmt.Errorf(`invalid duration for write timeout: "one minute"`),
+		},
+		"check if error is returned when path to key file is invalid": {
+			options: []ListenerOption{
+				WithKeyFile("/invalid/path"),
+			},
+			error: fmt.Errorf(`cannot open key file: "/invalid/path"`),
+		},
+		"check if error is returned when path to certificate file is invalid": {
+			options: []ListenerOption{
+				WithCertFile("/invalid/path"),
+			},
+			error: fmt.Errorf(`cannot open certificate file: "/invalid/path"`),
+		},
+		"check if empty cert/key path or empty timeouts are ignored": {
+			options: []ListenerOption{
+				WithKeyFile(""),
+				WithCertFile(""),
+				WithReadTimeout(""),
+				WithWriteTimeout(""),
+			},
+			expected: &ListenerOptions{
+				readTimeout:  defaultReadTimeout,
+				writeTimeout: defaultWriteTimeout,
+			},
+		},
+		"check if default timeouts can be overriden": {
+			options: []ListenerOption{
+				WithReadTimeout("1s"),
+				WithWriteTimeout("1m"),
+			},
+			expected: &ListenerOptions{
+				readTimeout:  time.Second,
+				writeTimeout: time.Minute,
+			},
+		},
+		"check if origins are set": {
+			options: []ListenerOption{
+				WithOrigins([]string{"test.com", "example.com"}),
+			},
+			expected: &ListenerOptions{
+				readTimeout:  defaultReadTimeout,
+				writeTimeout: defaultWriteTimeout,
+				origins:      []string{"test.com", "example.com"},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual, err := NewListenerOptions(test.options...)
+
+			if !reflect.DeepEqual(err, test.error) {
+				t.Errorf("error [%v] was expected to be [%v]", err, test.error)
+			}
+
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("options [%v] was expected to equal [%v]", actual, test.expected)
+			}
+		})
+	}
+}

--- a/pkg/transport/http/listener_options_test.go
+++ b/pkg/transport/http/listener_options_test.go
@@ -1,0 +1,22 @@
+package http
+
+// func TestParseListenerOptions(t *testing.T) {
+// 	duration := time.Second
+// 	options := specs.Options{
+// 		ReadTimeoutOption:  duration.String(),
+// 		WriteTimeoutOption: duration.String(),
+// 	}
+//
+// 	result, err := ParseListenerOptions(options)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+//
+// 	if result.ReadTimeout != duration {
+// 		t.Fatalf("unexpected read timeout %+v, expected %+v", result.ReadTimeout, duration)
+// 	}
+//
+// 	if result.WriteTimeout != duration {
+// 		t.Fatalf("unexpected write timeout %+v, expected %+v", result.ReadTimeout, duration)
+// 	}
+// }

--- a/pkg/transport/http/listener_options_test.go
+++ b/pkg/transport/http/listener_options_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func Test_NewListenerOptions(t *testing.T) {
+func TestNewListenerOptions(t *testing.T) {
 	type test struct {
 		options  []ListenerOption
 		error    error

--- a/pkg/transport/http/listener_test.go
+++ b/pkg/transport/http/listener_test.go
@@ -31,7 +31,7 @@ func NewMockListener(t *testing.T, nodes flow.Nodes, errs transport.Errs) (trans
 		origin = []string{"test.com"}
 
 		ctx      = logger.WithLogger(broker.NewContext())
-		listener = NewListener(addr, origin, nil)(ctx)
+		listener = NewListener(addr, WithOrigins(origin))(ctx)
 
 		json = json.NewConstructor()
 
@@ -336,7 +336,7 @@ func TestListenerForwarding(t *testing.T) {
 		return
 	}))
 
-	listener := NewListener(mock, []string{}, nil)(ctx)
+	listener := NewListener(mock)(ctx)
 
 	json := json.NewConstructor()
 	constructors := map[string]codec.Constructor{

--- a/pkg/transport/http/listener_test.go
+++ b/pkg/transport/http/listener_test.go
@@ -25,30 +25,36 @@ import (
 )
 
 func NewMockListener(t *testing.T, nodes flow.Nodes, errs transport.Errs) (transport.Listener, string) {
-	port := AvailablePort(t)
-	addr := fmt.Sprintf(":%d", port)
+	var (
+		port   = AvailablePort(t)
+		addr   = fmt.Sprintf(":%d", port)
+		origin = []string{"test.com"}
 
-	ctx := logger.WithLogger(broker.NewContext())
-	listener := NewListener(addr, nil)(ctx)
+		ctx      = logger.WithLogger(broker.NewContext())
+		listener = NewListener(addr, origin, nil)(ctx)
 
-	json := json.NewConstructor()
-	constructors := map[string]codec.Constructor{
-		json.Name(): json,
-	}
+		json = json.NewConstructor()
 
-	endpoints := []*transport.Endpoint{
-		{
-			Request: transport.NewObject(NewSimpleMockSpecs(), nil, nil),
-			Flow:    flow.NewManager(ctx, "test", nodes, nil, nil, nil),
-			Errs:    errs,
-			Options: specs.Options{
-				EndpointOption: "/",
-				MethodOption:   http.MethodPost,
-				CodecOption:    json.Name(),
+		constructors = map[string]codec.Constructor{
+			json.Name(): json,
+		}
+
+		endpoints = []*transport.Endpoint{
+			{
+				Request: &transport.Object{
+					Definition: NewSimpleMockSpecs(),
+				},
+				Flow: flow.NewManager(ctx, "test", nodes, nil, nil, nil),
+				Errs: errs,
+				Options: specs.Options{
+					EndpointOption: "/",
+					MethodOption:   http.MethodPost,
+					CodecOption:    json.Name(),
+				},
+				Response: transport.NewObject(NewSimpleMockSpecs(), nil, nil),
 			},
-			Response: transport.NewObject(NewSimpleMockSpecs(), nil, nil),
-		},
-	}
+		}
+	)
 
 	listener.Handle(ctx, endpoints, constructors)
 	go listener.Serve()
@@ -58,6 +64,96 @@ func NewMockListener(t *testing.T, nodes flow.Nodes, errs transport.Errs) (trans
 
 	endpoint := fmt.Sprintf("http://127.0.0.1:%d/", port)
 	return listener, endpoint
+}
+
+func TestCORS(t *testing.T) {
+	type test struct {
+		headers          map[string]string
+		shouldPresent    map[string]string
+		shouldNotPresent []string
+	}
+
+	tests := map[string]test{
+		"bad origin": {
+			headers: map[string]string{"Origin": "un.known"},
+			shouldPresent: map[string]string{
+				"Allow": "OPTIONS, POST",
+			},
+			shouldNotPresent: []string{
+				"Access-Control-Allow-Origin",
+				"Access-Control-Allow-Headers",
+			},
+		},
+		"good origin": {
+			headers: map[string]string{
+				"Origin":                         "test.com",
+				"Access-Control-Request-Method":  "POST",
+				"Access-Control-Request-Headers": "Authorization",
+			},
+			shouldPresent: map[string]string{
+				"Access-Control-Allow-Origin":  "test.com",
+				"Access-Control-Allow-Methods": "POST",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var (
+				ctx  = logger.WithLogger(broker.NewContext())
+				node = &specs.Node{
+					ID: "first",
+				}
+
+				called = 0
+				call   = NewCallerFunc(func(ctx context.Context, refs references.Store) error {
+					called++
+					return nil
+				})
+
+				nodes = flow.Nodes{
+					flow.NewNode(ctx, node, nil, call, nil, nil),
+				}
+			)
+
+			listener, endpoint := NewMockListener(t, nodes, nil)
+			defer listener.Close()
+
+			req, err := http.NewRequest(http.MethodOptions, endpoint, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for header, value := range test.headers {
+				req.Header.Set(header, value)
+			}
+
+			result, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if result.StatusCode != http.StatusOK {
+				t.Fatalf("unexpected status code %d", result.StatusCode)
+			}
+
+			for header, expected := range test.shouldPresent {
+				if value := result.Header.Get(header); value != expected {
+					t.Errorf("header %q should have value %q instead of %q", header, expected, value)
+				}
+			}
+
+			for _, header := range test.shouldNotPresent {
+				if result.Header.Get(header) != "" {
+					t.Errorf("header %q should not present in the response", header)
+				}
+			}
+
+			if called != 0 {
+				t.Errorf("node handler should not be called")
+			}
+		})
+	}
 }
 
 func TestListener(t *testing.T) {
@@ -240,7 +336,7 @@ func TestListenerForwarding(t *testing.T) {
 		return
 	}))
 
-	listener := NewListener(mock, nil)(ctx)
+	listener := NewListener(mock, []string{}, nil)(ctx)
 
 	json := json.NewConstructor()
 	constructors := map[string]codec.Constructor{

--- a/pkg/transport/http/middleware.go
+++ b/pkg/transport/http/middleware.go
@@ -1,0 +1,37 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/rs/cors"
+)
+
+// OptionsHandler creates a global handler for OPTIONS requests.
+func OptionsHandler(origins, headers, methods []string) http.Handler {
+	var allowOrigin func(origin string) bool
+
+	if len(origins) > 0 {
+		allowOrigin = func(origin string) bool {
+			for _, curr := range origins {
+				if curr == origin {
+					return true
+				}
+			}
+
+			return false
+		}
+	}
+
+	mw := cors.New(cors.Options{
+		AllowOriginFunc: allowOrigin,
+		AllowedHeaders:  headers,
+		AllowedMethods:  methods,
+		Debug:           true,
+	})
+
+	return mw.Handler(
+		http.HandlerFunc(
+			func(http.ResponseWriter, *http.Request) {},
+		),
+	)
+}

--- a/pkg/transport/http/middleware.go
+++ b/pkg/transport/http/middleware.go
@@ -26,7 +26,6 @@ func OptionsHandler(origins, headers, methods []string) http.Handler {
 		AllowOriginFunc: allowOrigin,
 		AllowedHeaders:  headers,
 		AllowedMethods:  methods,
-		Debug:           true,
 	})
 
 	return mw.Handler(

--- a/pkg/transport/http/options.go
+++ b/pkg/transport/http/options.go
@@ -14,10 +14,6 @@ const (
 	InsecureOption = "insecure"
 	// CAFileOption certificate authority file path
 	CAFileOption = "ca_file"
-	// CertFileOption certificate file path
-	CertFileOption = "cert_file"
-	// KeyFileOption certificate key file path
-	KeyFileOption = "key_file"
 	// ReadTimeoutOption represents the HTTP read timeout option key
 	ReadTimeoutOption = "read_timeout"
 	// WriteTimeoutOption represents the HTTP write timeout option key
@@ -37,54 +33,6 @@ const (
 	// MaxIdleConnsOption represents the max idle connections option key
 	MaxIdleConnsOption = "max_idle_conns"
 )
-
-// ListenerOptions represents the available HTTP options
-type ListenerOptions struct {
-	ReadTimeout  time.Duration
-	WriteTimeout time.Duration
-	CertFile     string
-	KeyFile      string
-}
-
-// ParseListenerOptions parses the given specs options into HTTP options
-func ParseListenerOptions(options specs.Options) (*ListenerOptions, error) {
-	result := &ListenerOptions{
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 5 * time.Second,
-	}
-
-	read, has := options[ReadTimeoutOption]
-	if has {
-		duration, err := time.ParseDuration(read)
-		if err != nil {
-			return nil, err
-		}
-
-		result.ReadTimeout = duration
-	}
-
-	write, has := options[WriteTimeoutOption]
-	if has {
-		duration, err := time.ParseDuration(write)
-		if err != nil {
-			return nil, err
-		}
-
-		result.WriteTimeout = duration
-	}
-
-	key, has := options[KeyFileOption]
-	if has {
-		result.KeyFile = key
-	}
-
-	crt, has := options[CertFileOption]
-	if has {
-		result.CertFile = crt
-	}
-
-	return result, nil
-}
 
 // EndpointOptions represents the available HTTP options
 type EndpointOptions struct {

--- a/pkg/transport/http/options_test.go
+++ b/pkg/transport/http/options_test.go
@@ -8,27 +8,6 @@ import (
 	"github.com/jexia/semaphore/pkg/specs"
 )
 
-func TestParseListenerOptions(t *testing.T) {
-	duration := time.Second
-	options := specs.Options{
-		ReadTimeoutOption:  duration.String(),
-		WriteTimeoutOption: duration.String(),
-	}
-
-	result, err := ParseListenerOptions(options)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if result.ReadTimeout != duration {
-		t.Fatalf("unexpected read timeout %+v, expected %+v", result.ReadTimeout, duration)
-	}
-
-	if result.WriteTimeout != duration {
-		t.Fatalf("unexpected write timeout %+v, expected %+v", result.ReadTimeout, duration)
-	}
-}
-
 func TestParseEndpointOptions(t *testing.T) {
 	duration := time.Second
 	method := "POST"

--- a/pkg/transport/http/unique.go
+++ b/pkg/transport/http/unique.go
@@ -1,0 +1,22 @@
+package http
+
+// UniqueStringItems collects strings to be returned as a list of unique items.
+// Note that it is not suitable for concurrent usage and does not guartantee the
+// order of items.
+type UniqueStringItems map[string]struct{}
+
+// Add item to the list.
+func (usi UniqueStringItems) Add(item string) {
+	usi[item] = struct{}{}
+}
+
+// Get the list of unique items.
+func (usi UniqueStringItems) Get() []string {
+	list := make([]string, 0, len(usi))
+
+	for key := range usi {
+		list = append(list, key)
+	}
+
+	return list
+}

--- a/vendor/github.com/rs/cors/.travis.yml
+++ b/vendor/github.com/rs/cors/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go:
+- "1.10"
+- "1.11"
+- "1.12"
+- tip
+matrix:
+  allow_failures:
+    - go: tip

--- a/vendor/github.com/rs/cors/LICENSE
+++ b/vendor/github.com/rs/cors/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2014 Olivier Poitrey <rs@dailymotion.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/rs/cors/README.md
+++ b/vendor/github.com/rs/cors/README.md
@@ -1,0 +1,115 @@
+# Go CORS handler [![godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/rs/cors) [![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/rs/cors/master/LICENSE) [![build](https://img.shields.io/travis/rs/cors.svg?style=flat)](https://travis-ci.org/rs/cors) [![Coverage](http://gocover.io/_badge/github.com/rs/cors)](http://gocover.io/github.com/rs/cors)
+
+CORS is a `net/http` handler implementing [Cross Origin Resource Sharing W3 specification](http://www.w3.org/TR/cors/) in Golang.
+
+## Getting Started
+
+After installing Go and setting up your [GOPATH](http://golang.org/doc/code.html#GOPATH), create your first `.go` file. We'll call it `server.go`.
+
+```go
+package main
+
+import (
+    "net/http"
+
+    "github.com/rs/cors"
+)
+
+func main() {
+    mux := http.NewServeMux()
+    mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        w.Write([]byte("{\"hello\": \"world\"}"))
+    })
+
+    // cors.Default() setup the middleware with default options being
+    // all origins accepted with simple methods (GET, POST). See
+    // documentation below for more options.
+    handler := cors.Default().Handler(mux)
+    http.ListenAndServe(":8080", handler)
+}
+```
+
+Install `cors`:
+
+    go get github.com/rs/cors
+
+Then run your server:
+
+    go run server.go
+
+The server now runs on `localhost:8080`:
+
+    $ curl -D - -H 'Origin: http://foo.com' http://localhost:8080/
+    HTTP/1.1 200 OK
+    Access-Control-Allow-Origin: foo.com
+    Content-Type: application/json
+    Date: Sat, 25 Oct 2014 03:43:57 GMT
+    Content-Length: 18
+
+    {"hello": "world"}
+
+### Allow * With Credentials Security Protection
+
+This library has been modified to avoid a well known security issue when configured with `AllowedOrigins` to `*` and `AllowCredentials` to `true`. Such setup used to make the library reflects the request `Origin` header value, working around a security protection embedded into the standard that makes clients to refuse such configuration. This behavior has been removed with [#55](https://github.com/rs/cors/issues/55) and [#57](https://github.com/rs/cors/issues/57).
+
+If you depend on this behavior and understand the implications, you can restore it using the `AllowOriginFunc` with `func(origin string) {return true}`.
+
+Please refer to [#55](https://github.com/rs/cors/issues/55) for more information about the security implications.
+
+### More Examples
+
+* `net/http`: [examples/nethttp/server.go](https://github.com/rs/cors/blob/master/examples/nethttp/server.go)
+* [Goji](https://goji.io): [examples/goji/server.go](https://github.com/rs/cors/blob/master/examples/goji/server.go)
+* [Martini](http://martini.codegangsta.io): [examples/martini/server.go](https://github.com/rs/cors/blob/master/examples/martini/server.go)
+* [Negroni](https://github.com/codegangsta/negroni): [examples/negroni/server.go](https://github.com/rs/cors/blob/master/examples/negroni/server.go)
+* [Alice](https://github.com/justinas/alice): [examples/alice/server.go](https://github.com/rs/cors/blob/master/examples/alice/server.go)
+* [HttpRouter](https://github.com/julienschmidt/httprouter): [examples/httprouter/server.go](https://github.com/rs/cors/blob/master/examples/httprouter/server.go)
+* [Gorilla](http://www.gorillatoolkit.org/pkg/mux): [examples/gorilla/server.go](https://github.com/rs/cors/blob/master/examples/gorilla/server.go)
+* [Buffalo](https://gobuffalo.io): [examples/buffalo/server.go](https://github.com/rs/cors/blob/master/examples/buffalo/server.go)
+* [Gin](https://gin-gonic.github.io/gin): [examples/gin/server.go](https://github.com/rs/cors/blob/master/examples/gin/server.go)
+* [Chi](https://github.com/go-chi/chi): [examples/chi/server.go](https://github.com/rs/cors/blob/master/examples/chi/server.go)
+
+## Parameters
+
+Parameters are passed to the middleware thru the `cors.New` method as follow:
+
+```go
+c := cors.New(cors.Options{
+    AllowedOrigins: []string{"http://foo.com", "http://foo.com:8080"},
+    AllowCredentials: true,
+    // Enable Debugging for testing, consider disabling in production
+    Debug: true,
+})
+
+// Insert the middleware
+handler = c.Handler(handler)
+```
+
+* **AllowedOrigins** `[]string`: A list of origins a cross-domain request can be executed from. If the special `*` value is present in the list, all origins will be allowed. An origin may contain a wildcard (`*`) to replace 0 or more characters (i.e.: `http://*.domain.com`). Usage of wildcards implies a small performance penality. Only one wildcard can be used per origin. The default value is `*`.
+* **AllowOriginFunc** `func (origin string) bool`: A custom function to validate the origin. It takes the origin as an argument and returns true if allowed, or false otherwise. If this option is set, the content of `AllowedOrigins` is ignored.
+* **AllowOriginRequestFunc** `func (r *http.Request origin string) bool`: A custom function to validate the origin. It takes the HTTP Request object and the origin as argument and returns true if allowed or false otherwise. If this option is set, the content of `AllowedOrigins` and `AllowOriginFunc` is ignored
+* **AllowedMethods** `[]string`: A list of methods the client is allowed to use with cross-domain requests. Default value is simple methods (`GET` and `POST`).
+* **AllowedHeaders** `[]string`: A list of non simple headers the client is allowed to use with cross-domain requests.
+* **ExposedHeaders** `[]string`: Indicates which headers are safe to expose to the API of a CORS API specification
+* **AllowCredentials** `bool`: Indicates whether the request can include user credentials like cookies, HTTP authentication or client side SSL certificates. The default is `false`.
+* **MaxAge** `int`: Indicates how long (in seconds) the results of a preflight request can be cached. The default is `0` which stands for no max age.
+* **OptionsPassthrough** `bool`: Instructs preflight to let other potential next handlers to process the `OPTIONS` method. Turn this on if your application handles `OPTIONS`.
+* **Debug** `bool`: Debugging flag adds additional output to debug server side CORS issues.
+
+See [API documentation](http://godoc.org/github.com/rs/cors) for more info.
+
+## Benchmarks
+
+    BenchmarkWithout          20000000    64.6 ns/op      8 B/op    1 allocs/op
+    BenchmarkDefault          3000000      469 ns/op    114 B/op    2 allocs/op
+    BenchmarkAllowedOrigin    3000000      608 ns/op    114 B/op    2 allocs/op
+    BenchmarkPreflight        20000000    73.2 ns/op      0 B/op    0 allocs/op
+    BenchmarkPreflightHeader  20000000    73.6 ns/op      0 B/op    0 allocs/op
+    BenchmarkParseHeaderList  2000000      847 ns/op    184 B/op    6 allocs/op
+    BenchmarkParse…Single     5000000      290 ns/op     32 B/op    3 allocs/op
+    BenchmarkParse…Normalized 2000000      776 ns/op    160 B/op    6 allocs/op
+
+## Licenses
+
+All source code is licensed under the [MIT License](https://raw.github.com/rs/cors/master/LICENSE).

--- a/vendor/github.com/rs/cors/cors.go
+++ b/vendor/github.com/rs/cors/cors.go
@@ -1,0 +1,425 @@
+/*
+Package cors is net/http handler to handle CORS related requests
+as defined by http://www.w3.org/TR/cors/
+
+You can configure it by passing an option struct to cors.New:
+
+    c := cors.New(cors.Options{
+        AllowedOrigins:   []string{"foo.com"},
+        AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodDelete},
+        AllowCredentials: true,
+    })
+
+Then insert the handler in the chain:
+
+    handler = c.Handler(handler)
+
+See Options documentation for more options.
+
+The resulting handler is a standard net/http handler.
+*/
+package cors
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Options is a configuration container to setup the CORS middleware.
+type Options struct {
+	// AllowedOrigins is a list of origins a cross-domain request can be executed from.
+	// If the special "*" value is present in the list, all origins will be allowed.
+	// An origin may contain a wildcard (*) to replace 0 or more characters
+	// (i.e.: http://*.domain.com). Usage of wildcards implies a small performance penalty.
+	// Only one wildcard can be used per origin.
+	// Default value is ["*"]
+	AllowedOrigins []string
+	// AllowOriginFunc is a custom function to validate the origin. It take the origin
+	// as argument and returns true if allowed or false otherwise. If this option is
+	// set, the content of AllowedOrigins is ignored.
+	AllowOriginFunc func(origin string) bool
+	// AllowOriginFunc is a custom function to validate the origin. It takes the HTTP Request object and the origin as
+	// argument and returns true if allowed or false otherwise. If this option is set, the content of `AllowedOrigins`
+	// and `AllowOriginFunc` is ignored.
+	AllowOriginRequestFunc func(r *http.Request, origin string) bool
+	// AllowedMethods is a list of methods the client is allowed to use with
+	// cross-domain requests. Default value is simple methods (HEAD, GET and POST).
+	AllowedMethods []string
+	// AllowedHeaders is list of non simple headers the client is allowed to use with
+	// cross-domain requests.
+	// If the special "*" value is present in the list, all headers will be allowed.
+	// Default value is [] but "Origin" is always appended to the list.
+	AllowedHeaders []string
+	// ExposedHeaders indicates which headers are safe to expose to the API of a CORS
+	// API specification
+	ExposedHeaders []string
+	// MaxAge indicates how long (in seconds) the results of a preflight request
+	// can be cached
+	MaxAge int
+	// AllowCredentials indicates whether the request can include user credentials like
+	// cookies, HTTP authentication or client side SSL certificates.
+	AllowCredentials bool
+	// OptionsPassthrough instructs preflight to let other potential next handlers to
+	// process the OPTIONS method. Turn this on if your application handles OPTIONS.
+	OptionsPassthrough bool
+	// Debugging flag adds additional output to debug server side CORS issues
+	Debug bool
+}
+
+// Logger generic interface for logger
+type Logger interface {
+	Printf(string, ...interface{})
+}
+
+// Cors http handler
+type Cors struct {
+	// Debug logger
+	Log Logger
+	// Normalized list of plain allowed origins
+	allowedOrigins []string
+	// List of allowed origins containing wildcards
+	allowedWOrigins []wildcard
+	// Optional origin validator function
+	allowOriginFunc func(origin string) bool
+	// Optional origin validator (with request) function
+	allowOriginRequestFunc func(r *http.Request, origin string) bool
+	// Normalized list of allowed headers
+	allowedHeaders []string
+	// Normalized list of allowed methods
+	allowedMethods []string
+	// Normalized list of exposed headers
+	exposedHeaders []string
+	maxAge         int
+	// Set to true when allowed origins contains a "*"
+	allowedOriginsAll bool
+	// Set to true when allowed headers contains a "*"
+	allowedHeadersAll bool
+	allowCredentials  bool
+	optionPassthrough bool
+}
+
+// New creates a new Cors handler with the provided options.
+func New(options Options) *Cors {
+	c := &Cors{
+		exposedHeaders:         convert(options.ExposedHeaders, http.CanonicalHeaderKey),
+		allowOriginFunc:        options.AllowOriginFunc,
+		allowOriginRequestFunc: options.AllowOriginRequestFunc,
+		allowCredentials:       options.AllowCredentials,
+		maxAge:                 options.MaxAge,
+		optionPassthrough:      options.OptionsPassthrough,
+	}
+	if options.Debug && c.Log == nil {
+		c.Log = log.New(os.Stdout, "[cors] ", log.LstdFlags)
+	}
+
+	// Normalize options
+	// Note: for origins and methods matching, the spec requires a case-sensitive matching.
+	// As it may error prone, we chose to ignore the spec here.
+
+	// Allowed Origins
+	if len(options.AllowedOrigins) == 0 {
+		if options.AllowOriginFunc == nil && options.AllowOriginRequestFunc == nil {
+			// Default is all origins
+			c.allowedOriginsAll = true
+		}
+	} else {
+		c.allowedOrigins = []string{}
+		c.allowedWOrigins = []wildcard{}
+		for _, origin := range options.AllowedOrigins {
+			// Normalize
+			origin = strings.ToLower(origin)
+			if origin == "*" {
+				// If "*" is present in the list, turn the whole list into a match all
+				c.allowedOriginsAll = true
+				c.allowedOrigins = nil
+				c.allowedWOrigins = nil
+				break
+			} else if i := strings.IndexByte(origin, '*'); i >= 0 {
+				// Split the origin in two: start and end string without the *
+				w := wildcard{origin[0:i], origin[i+1:]}
+				c.allowedWOrigins = append(c.allowedWOrigins, w)
+			} else {
+				c.allowedOrigins = append(c.allowedOrigins, origin)
+			}
+		}
+	}
+
+	// Allowed Headers
+	if len(options.AllowedHeaders) == 0 {
+		// Use sensible defaults
+		c.allowedHeaders = []string{"Origin", "Accept", "Content-Type", "X-Requested-With"}
+	} else {
+		// Origin is always appended as some browsers will always request for this header at preflight
+		c.allowedHeaders = convert(append(options.AllowedHeaders, "Origin"), http.CanonicalHeaderKey)
+		for _, h := range options.AllowedHeaders {
+			if h == "*" {
+				c.allowedHeadersAll = true
+				c.allowedHeaders = nil
+				break
+			}
+		}
+	}
+
+	// Allowed Methods
+	if len(options.AllowedMethods) == 0 {
+		// Default is spec's "simple" methods
+		c.allowedMethods = []string{http.MethodGet, http.MethodPost, http.MethodHead}
+	} else {
+		c.allowedMethods = convert(options.AllowedMethods, strings.ToUpper)
+	}
+
+	return c
+}
+
+// Default creates a new Cors handler with default options.
+func Default() *Cors {
+	return New(Options{})
+}
+
+// AllowAll create a new Cors handler with permissive configuration allowing all
+// origins with all standard methods with any header and credentials.
+func AllowAll() *Cors {
+	return New(Options{
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{
+			http.MethodHead,
+			http.MethodGet,
+			http.MethodPost,
+			http.MethodPut,
+			http.MethodPatch,
+			http.MethodDelete,
+		},
+		AllowedHeaders:   []string{"*"},
+		AllowCredentials: false,
+	})
+}
+
+// Handler apply the CORS specification on the request, and add relevant CORS headers
+// as necessary.
+func (c *Cors) Handler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+			c.logf("Handler: Preflight request")
+			c.handlePreflight(w, r)
+			// Preflight requests are standalone and should stop the chain as some other
+			// middleware may not handle OPTIONS requests correctly. One typical example
+			// is authentication middleware ; OPTIONS requests won't carry authentication
+			// headers (see #1)
+			if c.optionPassthrough {
+				h.ServeHTTP(w, r)
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+		} else {
+			c.logf("Handler: Actual request")
+			c.handleActualRequest(w, r)
+			h.ServeHTTP(w, r)
+		}
+	})
+}
+
+// HandlerFunc provides Martini compatible handler
+func (c *Cors) HandlerFunc(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+		c.logf("HandlerFunc: Preflight request")
+		c.handlePreflight(w, r)
+	} else {
+		c.logf("HandlerFunc: Actual request")
+		c.handleActualRequest(w, r)
+	}
+}
+
+// Negroni compatible interface
+func (c *Cors) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+		c.logf("ServeHTTP: Preflight request")
+		c.handlePreflight(w, r)
+		// Preflight requests are standalone and should stop the chain as some other
+		// middleware may not handle OPTIONS requests correctly. One typical example
+		// is authentication middleware ; OPTIONS requests won't carry authentication
+		// headers (see #1)
+		if c.optionPassthrough {
+			next(w, r)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	} else {
+		c.logf("ServeHTTP: Actual request")
+		c.handleActualRequest(w, r)
+		next(w, r)
+	}
+}
+
+// handlePreflight handles pre-flight CORS requests
+func (c *Cors) handlePreflight(w http.ResponseWriter, r *http.Request) {
+	headers := w.Header()
+	origin := r.Header.Get("Origin")
+
+	if r.Method != http.MethodOptions {
+		c.logf("  Preflight aborted: %s!=OPTIONS", r.Method)
+		return
+	}
+	// Always set Vary headers
+	// see https://github.com/rs/cors/issues/10,
+	//     https://github.com/rs/cors/commit/dbdca4d95feaa7511a46e6f1efb3b3aa505bc43f#commitcomment-12352001
+	headers.Add("Vary", "Origin")
+	headers.Add("Vary", "Access-Control-Request-Method")
+	headers.Add("Vary", "Access-Control-Request-Headers")
+
+	if origin == "" {
+		c.logf("  Preflight aborted: empty origin")
+		return
+	}
+	if !c.isOriginAllowed(r, origin) {
+		c.logf("  Preflight aborted: origin '%s' not allowed", origin)
+		return
+	}
+
+	reqMethod := r.Header.Get("Access-Control-Request-Method")
+	if !c.isMethodAllowed(reqMethod) {
+		c.logf("  Preflight aborted: method '%s' not allowed", reqMethod)
+		return
+	}
+	reqHeaders := parseHeaderList(r.Header.Get("Access-Control-Request-Headers"))
+	if !c.areHeadersAllowed(reqHeaders) {
+		c.logf("  Preflight aborted: headers '%v' not allowed", reqHeaders)
+		return
+	}
+	if c.allowedOriginsAll {
+		headers.Set("Access-Control-Allow-Origin", "*")
+	} else {
+		headers.Set("Access-Control-Allow-Origin", origin)
+	}
+	// Spec says: Since the list of methods can be unbounded, simply returning the method indicated
+	// by Access-Control-Request-Method (if supported) can be enough
+	headers.Set("Access-Control-Allow-Methods", strings.ToUpper(reqMethod))
+	if len(reqHeaders) > 0 {
+
+		// Spec says: Since the list of headers can be unbounded, simply returning supported headers
+		// from Access-Control-Request-Headers can be enough
+		headers.Set("Access-Control-Allow-Headers", strings.Join(reqHeaders, ", "))
+	}
+	if c.allowCredentials {
+		headers.Set("Access-Control-Allow-Credentials", "true")
+	}
+	if c.maxAge > 0 {
+		headers.Set("Access-Control-Max-Age", strconv.Itoa(c.maxAge))
+	}
+	c.logf("  Preflight response headers: %v", headers)
+}
+
+// handleActualRequest handles simple cross-origin requests, actual request or redirects
+func (c *Cors) handleActualRequest(w http.ResponseWriter, r *http.Request) {
+	headers := w.Header()
+	origin := r.Header.Get("Origin")
+
+	// Always set Vary, see https://github.com/rs/cors/issues/10
+	headers.Add("Vary", "Origin")
+	if origin == "" {
+		c.logf("  Actual request no headers added: missing origin")
+		return
+	}
+	if !c.isOriginAllowed(r, origin) {
+		c.logf("  Actual request no headers added: origin '%s' not allowed", origin)
+		return
+	}
+
+	// Note that spec does define a way to specifically disallow a simple method like GET or
+	// POST. Access-Control-Allow-Methods is only used for pre-flight requests and the
+	// spec doesn't instruct to check the allowed methods for simple cross-origin requests.
+	// We think it's a nice feature to be able to have control on those methods though.
+	if !c.isMethodAllowed(r.Method) {
+		c.logf("  Actual request no headers added: method '%s' not allowed", r.Method)
+
+		return
+	}
+	if c.allowedOriginsAll {
+		headers.Set("Access-Control-Allow-Origin", "*")
+	} else {
+		headers.Set("Access-Control-Allow-Origin", origin)
+	}
+	if len(c.exposedHeaders) > 0 {
+		headers.Set("Access-Control-Expose-Headers", strings.Join(c.exposedHeaders, ", "))
+	}
+	if c.allowCredentials {
+		headers.Set("Access-Control-Allow-Credentials", "true")
+	}
+	c.logf("  Actual response added headers: %v", headers)
+}
+
+// convenience method. checks if a logger is set.
+func (c *Cors) logf(format string, a ...interface{}) {
+	if c.Log != nil {
+		c.Log.Printf(format, a...)
+	}
+}
+
+// isOriginAllowed checks if a given origin is allowed to perform cross-domain requests
+// on the endpoint
+func (c *Cors) isOriginAllowed(r *http.Request, origin string) bool {
+	if c.allowOriginRequestFunc != nil {
+		return c.allowOriginRequestFunc(r, origin)
+	}
+	if c.allowOriginFunc != nil {
+		return c.allowOriginFunc(origin)
+	}
+	if c.allowedOriginsAll {
+		return true
+	}
+	origin = strings.ToLower(origin)
+	for _, o := range c.allowedOrigins {
+		if o == origin {
+			return true
+		}
+	}
+	for _, w := range c.allowedWOrigins {
+		if w.match(origin) {
+			return true
+		}
+	}
+	return false
+}
+
+// isMethodAllowed checks if a given method can be used as part of a cross-domain request
+// on the endpoing
+func (c *Cors) isMethodAllowed(method string) bool {
+	if len(c.allowedMethods) == 0 {
+		// If no method allowed, always return false, even for preflight request
+		return false
+	}
+	method = strings.ToUpper(method)
+	if method == http.MethodOptions {
+		// Always allow preflight requests
+		return true
+	}
+	for _, m := range c.allowedMethods {
+		if m == method {
+			return true
+		}
+	}
+	return false
+}
+
+// areHeadersAllowed checks if a given list of headers are allowed to used within
+// a cross-domain request.
+func (c *Cors) areHeadersAllowed(requestedHeaders []string) bool {
+	if c.allowedHeadersAll || len(requestedHeaders) == 0 {
+		return true
+	}
+	for _, header := range requestedHeaders {
+		header = http.CanonicalHeaderKey(header)
+		found := false
+		for _, h := range c.allowedHeaders {
+			if h == header {
+				found = true
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/rs/cors/go.mod
+++ b/vendor/github.com/rs/cors/go.mod
@@ -1,0 +1,1 @@
+module github.com/rs/cors

--- a/vendor/github.com/rs/cors/utils.go
+++ b/vendor/github.com/rs/cors/utils.go
@@ -1,0 +1,71 @@
+package cors
+
+import "strings"
+
+const toLower = 'a' - 'A'
+
+type converter func(string) string
+
+type wildcard struct {
+	prefix string
+	suffix string
+}
+
+func (w wildcard) match(s string) bool {
+	return len(s) >= len(w.prefix)+len(w.suffix) && strings.HasPrefix(s, w.prefix) && strings.HasSuffix(s, w.suffix)
+}
+
+// convert converts a list of string using the passed converter function
+func convert(s []string, c converter) []string {
+	out := []string{}
+	for _, i := range s {
+		out = append(out, c(i))
+	}
+	return out
+}
+
+// parseHeaderList tokenize + normalize a string containing a list of headers
+func parseHeaderList(headerList string) []string {
+	l := len(headerList)
+	h := make([]byte, 0, l)
+	upper := true
+	// Estimate the number headers in order to allocate the right splice size
+	t := 0
+	for i := 0; i < l; i++ {
+		if headerList[i] == ',' {
+			t++
+		}
+	}
+	headers := make([]string, 0, t)
+	for i := 0; i < l; i++ {
+		b := headerList[i]
+		switch {
+		case b >= 'a' && b <= 'z':
+			if upper {
+				h = append(h, b-toLower)
+			} else {
+				h = append(h, b)
+			}
+		case b >= 'A' && b <= 'Z':
+			if !upper {
+				h = append(h, b+toLower)
+			} else {
+				h = append(h, b)
+			}
+		case b == '-' || b == '_' || (b >= '0' && b <= '9'):
+			h = append(h, b)
+		}
+
+		if b == ' ' || b == ',' || i == l-1 {
+			if len(h) > 0 {
+				// Flush the found header
+				headers = append(headers, string(h))
+				h = h[:0]
+				upper = true
+			}
+		} else {
+			upper = b == '-' || b == '_'
+		}
+	}
+	return headers
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,6 +190,9 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
+# github.com/rs/cors v1.7.0
+## explicit
+github.com/rs/cors
 # github.com/spf13/cobra v0.0.6
 ## explicit
 github.com/spf13/cobra


### PR DESCRIPTION
Related to https://github.com/jexia/semaphore/issues/74

Includes support for:
- `Access-Control-Allow-Origin` 
- `Access-Control-Request-Method`
- `Access-Control-Request-Headers`

Other changes:
- introduce `ListenerOption`