### PR TITLE
refactor: introducing node types

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -336,7 +336,7 @@ func TestClosingRunningFlows(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	timeout := 100 * time.Microsecond
+	timeout := 100 * time.Millisecond
 	run := make(chan struct{})
 
 	ctx := logger.WithLogger(broker.NewContext())

--- a/pkg/providers/hcl/specs.go
+++ b/pkg/providers/hcl/specs.go
@@ -91,7 +91,7 @@ func ParseIntermediateFlow(ctx *broker.Context, flow Flow) (*specs.Flow, error) 
 	result := specs.Flow{
 		Name:    flow.Name,
 		Input:   input,
-		Nodes:   []*specs.Node{},
+		Nodes:   specs.NodeList{},
 		Output:  output,
 		OnError: &specs.OnError{},
 	}
@@ -211,7 +211,7 @@ func ParseIntermediateProxy(ctx *broker.Context, proxy Proxy) (*specs.Proxy, err
 
 	result := specs.Proxy{
 		Name:    proxy.Name,
-		Nodes:   []*specs.Node{},
+		Nodes:   specs.NodeList{},
 		Forward: forward,
 		OnError: &specs.OnError{},
 	}
@@ -530,6 +530,7 @@ func ParseIntermediateNode(ctx *broker.Context, dependencies map[string]*specs.N
 	}
 
 	result := specs.Node{
+		Type:         specs.NodeIntermediate,
 		DependsOn:    make(map[string]*specs.Node, len(node.DependsOn)),
 		ID:           node.Name,
 		Name:         node.Name,
@@ -537,6 +538,10 @@ func ParseIntermediateNode(ctx *broker.Context, dependencies map[string]*specs.N
 		ExpectStatus: node.ExpectStatus,
 		Rollback:     rollback,
 		OnError:      &specs.OnError{},
+	}
+
+	if node.Request != nil {
+		result.Type = specs.NodeCall
 	}
 
 	if node.OnError != nil {
@@ -720,6 +725,7 @@ func ParseIntermediateResources(ctx *broker.Context, dependencies map[string]*sp
 		}
 
 		node := &specs.Node{
+			Type:      specs.NodeIntermediate,
 			DependsOn: DependenciesExcept(dependencies, prop.Name),
 			ID:        prop.Name,
 			Call: &specs.Call{
@@ -743,6 +749,7 @@ func ParseIntermediateCondition(ctx *broker.Context, dependencies map[string]*sp
 	}
 
 	expression := &specs.Node{
+		Type:      specs.NodeCondition,
 		ID:        condition.Expression,
 		Name:      "condition",
 		DependsOn: map[string]*specs.Node{},

--- a/pkg/specs/flows.go
+++ b/pkg/specs/flows.go
@@ -199,6 +199,21 @@ func (nodes NodeList) Get(name string) *Node {
 	return nil
 }
 
+// NodeType represents the type of the given node.
+// A type determains the purpose of the node but not the implementation.
+type NodeType string
+
+var (
+	// NodeCall is assigned when the given node is used to call a external service
+	NodeCall NodeType = "call"
+	// NodeCondition is assigned when the given node is used to execute a
+	// conditional expression.
+	NodeCondition NodeType = "condition"
+	// NodeIntermediate is assigned when the node is used as a coming in
+	// between nodes.
+	NodeIntermediate NodeType = "intermediate"
+)
+
 // Node represents a point inside a given flow where a request or rollback could be preformed.
 // Nodes could be executed synchronously or asynchronously.
 // All calls are referencing a service method, the service should match the alias defined inside the service.
@@ -206,6 +221,7 @@ func (nodes NodeList) Get(name string) *Node {
 // A call could contain the request headers, request body, rollback, and the execution type.
 type Node struct {
 	*metadata.Meta
+	Type         NodeType         `json:"type,omitempty"`
 	ID           string           `json:"id,omitempty"`
 	Name         string           `json:"name,omitempty"`
 	Condition    *Condition       `json:"condition,omitempty"`

--- a/pkg/specs/flows.go
+++ b/pkg/specs/flows.go
@@ -200,7 +200,7 @@ func (nodes NodeList) Get(name string) *Node {
 }
 
 // NodeType represents the type of the given node.
-// A type determains the purpose of the node but not the implementation.
+// A type determines the purpose of the node but not the implementation.
 type NodeType string
 
 var (


### PR DESCRIPTION
Node types determine the purpose of the node but not the implementation. These determinations could be used to visualize the purpose of a node.