### PR TITLE
Specs intermediate nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM golang:1.14 AS build
 
 ARG version=unknown
-ARG build=unkown
-ARG label=unkown
+ARG build=unknown
+ARG label=unknown
 
 WORKDIR /app
 

--- a/pkg/checks/checks_test.go
+++ b/pkg/checks/checks_test.go
@@ -29,7 +29,7 @@ func TestDuplicateManifests(t *testing.T) {
 		"duplicate node": {
 			&specs.Flow{
 				Name: "first",
-				Nodes: []*specs.Node{
+				Nodes: specs.NodeList{
 					{
 						ID: "dup",
 					},
@@ -42,7 +42,7 @@ func TestDuplicateManifests(t *testing.T) {
 		"duplicate proxy node": {
 			&specs.Proxy{
 				Name: "first",
-				Nodes: []*specs.Node{
+				Nodes: specs.NodeList{
 					{
 						ID: "dup",
 					},
@@ -109,7 +109,7 @@ func TestReservedKeywordsManifests(t *testing.T) {
 		"error": {
 			&specs.Flow{
 				Name: "first",
-				Nodes: []*specs.Node{
+				Nodes: specs.NodeList{
 					{
 						ID: "error",
 					},
@@ -119,7 +119,7 @@ func TestReservedKeywordsManifests(t *testing.T) {
 		"input": {
 			&specs.Flow{
 				Name: "first",
-				Nodes: []*specs.Node{
+				Nodes: specs.NodeList{
 					{
 						ID: "input",
 					},
@@ -129,7 +129,7 @@ func TestReservedKeywordsManifests(t *testing.T) {
 		"stack": {
 			&specs.Flow{
 				Name: "first",
-				Nodes: []*specs.Node{
+				Nodes: specs.NodeList{
 					{
 						ID: "stack",
 					},
@@ -153,7 +153,7 @@ func TestDuplicateNodes(t *testing.T) {
 	tests := map[string]*specs.Flow{
 		"simple": {
 			Name: "first",
-			Nodes: []*specs.Node{
+			Nodes: specs.NodeList{
 				{
 					ID: "dup",
 				},

--- a/pkg/codec/metadata/manager_test.go
+++ b/pkg/codec/metadata/manager_test.go
@@ -135,7 +135,7 @@ func TestManagerUnmarshal(t *testing.T) {
 
 			input := MD{
 				"example": "hello",
-				"unkown":  "hello",
+				"unknown": "hello",
 			}
 
 			expected := MD{

--- a/pkg/core/flow.go
+++ b/pkg/core/flow.go
@@ -35,7 +35,7 @@ func Apply(ctx *broker.Context, mem functions.Collection, services specs.Service
 
 		for index, node := range manager.GetNodes() {
 			arguments := []flow.NodeOption{
-				flow.WithNodeMiddleware(&flow.NodeMiddleware{
+				flow.WithNodeMiddleware(flow.NodeMiddleware{
 					BeforeDo:       options.BeforeNodeDo,
 					AfterDo:        options.AfterNodeDo,
 					BeforeRollback: options.BeforeNodeRollback,

--- a/pkg/core/flow.go
+++ b/pkg/core/flow.go
@@ -189,7 +189,13 @@ func NewRequest(ctx *broker.Context, node *specs.Node, mem functions.Collection,
 
 	stack := mem[params]
 	metadata := metadata.NewManager(ctx, node.ID, params.Header)
-	return flow.NewRequest(stack, codec, metadata), nil
+	request := &flow.Request{
+		Functions: stack,
+		Codec:     codec,
+		Metadata:  metadata,
+	}
+
+	return request, nil
 }
 
 // NewForward constructs a flow caller for the given call.

--- a/pkg/core/flow.go
+++ b/pkg/core/flow.go
@@ -141,7 +141,7 @@ func NewServiceCall(ctx *broker.Context, mem functions.Collection, services spec
 			}
 
 			forwarding.ResolvePropertyReferences(reference, node.DependsOn)
-			err = dependencies.ResolveNode(manager, node, make(map[string]*specs.Node))
+			err = dependencies.ResolveNode(manager, node, make(specs.Dependencies))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/core/flow.go
+++ b/pkg/core/flow.go
@@ -43,6 +43,11 @@ func Apply(ctx *broker.Context, mem functions.Collection, services specs.Service
 				}),
 			}
 
+			if node.Intermediate != nil {
+				stack := mem[node.Intermediate]
+				arguments = append(arguments, flow.WithFunctions(stack))
+			}
+
 			if node.Condition != nil {
 				arguments = append(arguments, flow.WithCondition(condition.New(ctx, mem, node.Condition)))
 			}

--- a/pkg/dependencies/dependencies.go
+++ b/pkg/dependencies/dependencies.go
@@ -13,7 +13,7 @@ func ResolveFlows(ctx *broker.Context, flows specs.FlowListInterface) error {
 
 	for _, flow := range flows {
 		for _, node := range flow.GetNodes() {
-			err := ResolveNode(flow, node, make(map[string]*specs.Node))
+			err := ResolveNode(flow, node, make(specs.Dependencies))
 			if err != nil {
 				return err
 			}
@@ -24,7 +24,7 @@ func ResolveFlows(ctx *broker.Context, flows specs.FlowListInterface) error {
 }
 
 // ResolveNode resolves the given call dependencies and attempts to detect any circular dependencies
-func ResolveNode(manager specs.FlowInterface, node *specs.Node, unresolved map[string]*specs.Node) error {
+func ResolveNode(manager specs.FlowInterface, node *specs.Node, unresolved specs.Dependencies) error {
 	if len(node.DependsOn) == 0 {
 		return nil
 	}

--- a/pkg/dependencies/dependencies_test.go
+++ b/pkg/dependencies/dependencies_test.go
@@ -12,7 +12,7 @@ func TestResolveManifestDependencies(t *testing.T) {
 	flows := specs.FlowListInterface{
 		&specs.Flow{
 			Name: "first",
-			Nodes: []*specs.Node{
+			Nodes: specs.NodeList{
 				{
 					ID: "first",
 				},
@@ -33,7 +33,7 @@ func TestResolveManifestDependencies(t *testing.T) {
 		},
 		&specs.Flow{
 			Name: "second",
-			Nodes: []*specs.Node{
+			Nodes: specs.NodeList{
 				{
 					ID: "first",
 				},
@@ -54,7 +54,7 @@ func TestResolveManifestDependencies(t *testing.T) {
 		},
 		&specs.Flow{
 			Name: "third",
-			Nodes: []*specs.Node{
+			Nodes: specs.NodeList{
 				{
 					ID: "first",
 				},
@@ -75,7 +75,7 @@ func TestResolveManifestDependencies(t *testing.T) {
 		},
 		&specs.Proxy{
 			Name: "first",
-			Nodes: []*specs.Node{
+			Nodes: specs.NodeList{
 				{
 					ID: "first",
 				},
@@ -96,7 +96,7 @@ func TestResolveManifestDependencies(t *testing.T) {
 		},
 		&specs.Proxy{
 			Name: "second",
-			Nodes: []*specs.Node{
+			Nodes: specs.NodeList{
 				{
 					ID: "first",
 				},
@@ -117,7 +117,7 @@ func TestResolveManifestDependencies(t *testing.T) {
 		},
 		&specs.Proxy{
 			Name: "third",
-			Nodes: []*specs.Node{
+			Nodes: specs.NodeList{
 				{
 					ID: "first",
 				},
@@ -161,7 +161,7 @@ func TestResolveManifestDependencies(t *testing.T) {
 
 func TestResolveCallDependencies(t *testing.T) {
 	flow := &specs.Flow{
-		Nodes: []*specs.Node{
+		Nodes: specs.NodeList{
 			{
 				ID: "first",
 			},
@@ -181,7 +181,7 @@ func TestResolveCallDependencies(t *testing.T) {
 		},
 	}
 
-	tests := []*specs.Node{
+	tests := specs.NodeList{
 		flow.Nodes[1],
 		flow.Nodes[2],
 	}
@@ -202,7 +202,7 @@ func TestResolveCallDependencies(t *testing.T) {
 
 func TestCallCircularDependenciesDetection(t *testing.T) {
 	flow := &specs.Flow{
-		Nodes: []*specs.Node{
+		Nodes: specs.NodeList{
 			{
 				ID: "first",
 				DependsOn: map[string]*specs.Node{
@@ -218,7 +218,7 @@ func TestCallCircularDependenciesDetection(t *testing.T) {
 		},
 	}
 
-	tests := []*specs.Node{
+	tests := specs.NodeList{
 		flow.Nodes[0],
 		flow.Nodes[1],
 	}
@@ -233,7 +233,7 @@ func TestCallCircularDependenciesDetection(t *testing.T) {
 
 func TestSelfDependencyDetection(t *testing.T) {
 	flow := &specs.Flow{
-		Nodes: []*specs.Node{
+		Nodes: specs.NodeList{
 			{
 				ID: "first",
 				DependsOn: map[string]*specs.Node{
@@ -249,7 +249,7 @@ func TestSelfDependencyDetection(t *testing.T) {
 		},
 	}
 
-	tests := []*specs.Node{
+	tests := specs.NodeList{
 		flow.Nodes[0],
 	}
 

--- a/pkg/flow/caller.go
+++ b/pkg/flow/caller.go
@@ -39,6 +39,12 @@ type CallOptions struct {
 	ExpectedStatus []int
 }
 
+// Call represents a transport caller implementation
+type Call interface {
+	References() []*specs.Property
+	Do(context.Context, references.Store) error
+}
+
 // NewCall constructs a new flow caller from the given transport caller and
 func NewCall(parent *broker.Context, node *specs.Node, options *CallOptions) Call {
 	module := broker.WithModule(parent, "caller", node.ID)

--- a/pkg/flow/caller.go
+++ b/pkg/flow/caller.go
@@ -39,11 +39,10 @@ type CallOptions struct {
 
 // Call represents a transport caller implementation
 type Call interface {
-	References() []*specs.Property
 	Do(context.Context, references.Store) error
 }
 
-// NewCall constructs a new flow caller from the given transport caller and
+// NewCall constructs a new flow caller from the given transport caller and options
 func NewCall(parent *broker.Context, node *specs.Node, options *CallOptions) Call {
 	module := broker.WithModule(parent, "caller", node.ID)
 	ctx := logger.WithFields(logger.WithLogger(module), zap.String("node", node.ID))
@@ -76,16 +75,10 @@ type Caller struct {
 	node           *specs.Node
 	method         transport.Method
 	transport      transport.Call
-	references     []*specs.Property
 	request        *Request
 	response       *Request
 	err            *OnError
 	ExpectedStatus map[int]struct{}
-}
-
-// References returns the references inside the configured transport caller
-func (caller *Caller) References() []*specs.Property {
-	return caller.references
 }
 
 // Do is called by the flow manager to call the configured service

--- a/pkg/flow/caller.go
+++ b/pkg/flow/caller.go
@@ -47,7 +47,7 @@ func NewCall(parent *broker.Context, node *specs.Node, options *CallOptions) Cal
 	module := broker.WithModule(parent, "caller", node.ID)
 	ctx := logger.WithFields(logger.WithLogger(module), zap.String("node", node.ID))
 
-	result := &Caller{
+	result := &caller{
 		ctx:            ctx,
 		node:           node,
 		transport:      options.Transport,
@@ -70,7 +70,7 @@ func NewCall(parent *broker.Context, node *specs.Node, options *CallOptions) Cal
 }
 
 // Caller represents a flow transport caller
-type Caller struct {
+type caller struct {
 	ctx            *broker.Context
 	node           *specs.Node
 	method         transport.Method
@@ -82,7 +82,7 @@ type Caller struct {
 }
 
 // Do is called by the flow manager to call the configured service
-func (caller *Caller) Do(ctx context.Context, store references.Store) error {
+func (caller *caller) Do(ctx context.Context, store references.Store) error {
 	reader, writer := io.Pipe()
 	w := transport.NewResponseWriter(writer)
 	r := &transport.Request{
@@ -160,7 +160,7 @@ func (caller *Caller) Do(ctx context.Context, store references.Store) error {
 }
 
 // HandleErr handles a thrown service error. If a error response is defined is it decoded
-func (caller *Caller) HandleErr(w *transport.Writer, reader io.Reader, store references.Store) error {
+func (caller *caller) HandleErr(w *transport.Writer, reader io.Reader, store references.Store) error {
 	var status interface{}
 	var message interface{}
 

--- a/pkg/flow/caller.go
+++ b/pkg/flow/caller.go
@@ -20,20 +20,11 @@ import (
 // ErrAbortFlow represents the error thrown when a flow has to be aborted
 var ErrAbortFlow = errors.New("abort flow")
 
-// NewRequest constructs a new request for the given codec and header manager
-func NewRequest(functions functions.Stack, codec codec.Manager, metadata *metadata.Manager) *Request {
-	return &Request{
-		functions: functions,
-		codec:     codec,
-		metadata:  metadata,
-	}
-}
-
 // Request represents a codec and metadata manager
 type Request struct {
-	functions functions.Stack
-	codec     codec.Manager
-	metadata  *metadata.Manager
+	Functions functions.Stack
+	Codec     codec.Manager
+	Metadata  *metadata.Manager
 }
 
 // CallOptions represents the available options that could be used to construct a new flow caller
@@ -106,24 +97,24 @@ func (caller *Caller) Do(ctx context.Context, store references.Store) error {
 	}
 
 	if caller.request != nil {
-		if caller.request.functions != nil {
-			err := ExecuteFunctions(caller.request.functions, store)
+		if caller.request.Functions != nil {
+			err := ExecuteFunctions(caller.request.Functions, store)
 			if err != nil {
 				return err
 			}
 		}
 
-		if caller.request.metadata != nil {
-			r.Header = caller.request.metadata.Marshal(store)
+		if caller.request.Metadata != nil {
+			r.Header = caller.request.Metadata.Marshal(store)
 		}
 
-		if caller.request.codec != nil {
-			body, err := caller.request.codec.Marshal(store)
+		if caller.request.Codec != nil {
+			body, err := caller.request.Codec.Marshal(store)
 			if err != nil {
 				return err
 			}
 
-			r.Codec = caller.request.codec.Name()
+			r.Codec = caller.request.Codec.Name()
 			r.Body = body
 		}
 	}
@@ -153,22 +144,22 @@ func (caller *Caller) Do(ctx context.Context, store references.Store) error {
 	}
 
 	if caller.response != nil {
-		if caller.response.codec != nil {
-			err := caller.response.codec.Unmarshal(reader, store)
+		if caller.response.Codec != nil {
+			err := caller.response.Codec.Unmarshal(reader, store)
 			if err != nil {
 				return err
 			}
 		}
 
-		if caller.response.functions != nil {
-			err := ExecuteFunctions(caller.response.functions, store)
+		if caller.response.Functions != nil {
+			err := ExecuteFunctions(caller.response.Functions, store)
 			if err != nil {
 				return err
 			}
 		}
 
-		if caller.response.metadata != nil {
-			caller.response.metadata.Unmarshal(w.Header(), store)
+		if caller.response.Metadata != nil {
+			caller.response.Metadata.Unmarshal(w.Header(), store)
 		}
 	}
 
@@ -218,7 +209,7 @@ func (caller *Caller) HandleErr(w *transport.Writer, reader io.Reader, store ref
 		}
 
 		if caller.err.metadata != nil {
-			caller.response.metadata.Unmarshal(w.Header(), store)
+			caller.response.Metadata.Unmarshal(w.Header(), store)
 		}
 	}
 

--- a/pkg/flow/caller.go
+++ b/pkg/flow/caller.go
@@ -29,6 +29,13 @@ func NewRequest(functions functions.Stack, codec codec.Manager, metadata *metada
 	}
 }
 
+// Request represents a codec and metadata manager
+type Request struct {
+	functions functions.Stack
+	codec     codec.Manager
+	metadata  *metadata.Manager
+}
+
 // CallOptions represents the available options that could be used to construct a new flow caller
 type CallOptions struct {
 	Transport      transport.Call
@@ -70,13 +77,6 @@ func NewCall(parent *broker.Context, node *specs.Node, options *CallOptions) Cal
 	}
 
 	return result
-}
-
-// Request represents a codec and metadata manager
-type Request struct {
-	functions functions.Stack
-	codec     codec.Manager
-	metadata  *metadata.Manager
 }
 
 // Caller represents a flow transport caller

--- a/pkg/flow/caller_test.go
+++ b/pkg/flow/caller_test.go
@@ -64,13 +64,6 @@ func (counter *fncounter) handle(references.Store) error {
 	return counter.err
 }
 
-func TestNewRequest(t *testing.T) {
-	request := NewRequest(nil, nil, nil)
-	if request == nil {
-		t.Fatal("unexpected result, expected a request to be returned")
-	}
-}
-
 func TestNewCall(t *testing.T) {
 	ctx := logger.WithLogger(broker.NewContext())
 	node := &specs.Node{}
@@ -104,7 +97,7 @@ func TestCallExecution(t *testing.T) {
 			node: &specs.Node{},
 			options: &CallOptions{
 				Request: &Request{
-					codec: codec,
+					Codec: codec,
 				},
 				Response: &Request{},
 			},
@@ -114,7 +107,7 @@ func TestCallExecution(t *testing.T) {
 			options: &CallOptions{
 				Request: &Request{},
 				Response: &Request{
-					codec: codec,
+					Codec: codec,
 				},
 			},
 		},
@@ -122,7 +115,7 @@ func TestCallExecution(t *testing.T) {
 			node: &specs.Node{},
 			options: &CallOptions{
 				Request: &Request{
-					functions: functions.Stack{
+					Functions: functions.Stack{
 						"sample": &functions.Function{
 							Fn: func(store references.Store) error { return nil },
 						},
@@ -136,7 +129,7 @@ func TestCallExecution(t *testing.T) {
 			options: &CallOptions{
 				Request: &Request{},
 				Response: &Request{
-					functions: functions.Stack{
+					Functions: functions.Stack{
 						"sample": &functions.Function{
 							Fn: func(store references.Store) error { return nil },
 						},
@@ -182,7 +175,7 @@ func TestCallFunctionsExecution(t *testing.T) {
 				node:     &specs.Node{},
 				options: &CallOptions{
 					Request: &Request{
-						functions: functions.Stack{
+						Functions: functions.Stack{
 							"sample": &functions.Function{
 								Fn: counter.handle,
 							},
@@ -202,7 +195,7 @@ func TestCallFunctionsExecution(t *testing.T) {
 				options: &CallOptions{
 					Request: &Request{},
 					Response: &Request{
-						functions: functions.Stack{
+						Functions: functions.Stack{
 							"sample": &functions.Function{
 								Fn: counter.handle,
 							},
@@ -220,7 +213,7 @@ func TestCallFunctionsExecution(t *testing.T) {
 				node:     &specs.Node{},
 				options: &CallOptions{
 					Request: &Request{
-						functions: functions.Stack{
+						Functions: functions.Stack{
 							"first": &functions.Function{
 								Fn: counter.handle,
 							},
@@ -230,7 +223,7 @@ func TestCallFunctionsExecution(t *testing.T) {
 						},
 					},
 					Response: &Request{
-						functions: functions.Stack{
+						Functions: functions.Stack{
 							"first": &functions.Function{
 								Fn: counter.handle,
 							},

--- a/pkg/flow/caller_test.go
+++ b/pkg/flow/caller_test.go
@@ -75,6 +75,17 @@ func TestNewCall(t *testing.T) {
 	}
 }
 
+func TestCallReferences(t *testing.T) {
+	ctx := logger.WithLogger(broker.NewContext())
+	node := &specs.Node{}
+	options := &CallOptions{}
+
+	result := NewCall(ctx, node, options)
+	if result == nil {
+		t.Fatal("unexpected result, expected a call to be constructed")
+	}
+}
+
 func TestCallExecution(t *testing.T) {
 	type test struct {
 		node    *specs.Node

--- a/pkg/flow/condition.go
+++ b/pkg/flow/condition.go
@@ -37,6 +37,10 @@ func (condition *Condition) Eval(ctx *broker.Context, store references.Store) (b
 		return false, err
 	}
 
+	if condition.expression == nil {
+		return true, nil
+	}
+
 	parameters := make(map[string]interface{}, len(condition.expression.GetParameters().Params))
 	for key, param := range condition.expression.GetParameters().Params {
 		value := param.Default

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -13,12 +13,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// Call represents a transport caller implementation
-type Call interface {
-	References() []*specs.Property
-	Do(context.Context, references.Store) error
-}
-
 // NewManager constructs a new manager for the given flow.
 // Branches are constructed for the constructed nodes to optimalise performance.
 // Various variables such as the amount of nodes, references and loose ends are collected to optimalise allocations during runtime.

--- a/pkg/flow/flow_test.go
+++ b/pkg/flow/flow_test.go
@@ -26,15 +26,10 @@ func (codec *MockCodec) Unmarshal(io.Reader, references.Store) error {
 }
 
 type caller struct {
-	name       string
-	Counter    int
-	mutex      sync.Mutex
-	Err        error
-	references []*specs.Property
-}
-
-func (caller *caller) References() []*specs.Property {
-	return caller.references
+	name    string
+	Counter int
+	mutex   sync.Mutex
+	Err     error
 }
 
 func (caller *caller) Do(context.Context, references.Store) error {

--- a/pkg/flow/flow_test.go
+++ b/pkg/flow/flow_test.go
@@ -25,14 +25,14 @@ func (codec *MockCodec) Unmarshal(io.Reader, references.Store) error {
 	return nil
 }
 
-type caller struct {
+type mocker struct {
 	name    string
 	Counter int
 	mutex   sync.Mutex
 	Err     error
 }
 
-func (caller *caller) Do(context.Context, references.Store) error {
+func (caller *mocker) Do(context.Context, references.Store) error {
 	caller.mutex.Lock()
 	caller.Counter++
 	caller.mutex.Unlock()
@@ -93,7 +93,7 @@ func TestNewManager(t *testing.T) {
 }
 
 func TestCallFlowManager(t *testing.T) {
-	caller := &caller{}
+	caller := &mocker{}
 	nodes, manager := NewMockFlowManager(caller, nil)
 	err := manager.Do(context.Background(), nil)
 	if err != nil {
@@ -110,12 +110,12 @@ func TestFailFlowManager(t *testing.T) {
 	reverts := 2
 	calls := 2
 
-	rollback := &caller{}
-	call := &caller{}
+	rollback := &mocker{}
+	call := &mocker{}
 
 	nodes, manager := NewMockFlowManager(call, rollback)
 
-	nodes[2].Call = &caller{Err: expected}
+	nodes[2].Call = &mocker{Err: expected}
 
 	err := manager.Do(context.Background(), nil)
 	if !errors.Is(err, expected) {
@@ -135,7 +135,7 @@ func TestFailFlowManager(t *testing.T) {
 
 func TestBeforeDoFlow(t *testing.T) {
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	_, manager := NewMockFlowManager(call, nil)
 
 	manager.BeforeDo = func(ctx context.Context, manager *Manager, store references.Store) (context.Context, error) {
@@ -156,7 +156,7 @@ func TestBeforeDoFlow(t *testing.T) {
 func TestBeforeDoFlowErr(t *testing.T) {
 	expected := errors.New("unexpected error")
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	_, manager := NewMockFlowManager(call, nil)
 
 	manager.BeforeDo = func(ctx context.Context, manager *Manager, store references.Store) (context.Context, error) {
@@ -177,7 +177,7 @@ func TestBeforeDoFlowErr(t *testing.T) {
 func TestAfterDoFlowErr(t *testing.T) {
 	expected := errors.New("unexpected error")
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	_, manager := NewMockFlowManager(call, nil)
 
 	manager.AfterDo = func(ctx context.Context, manager *Manager, store references.Store) (context.Context, error) {
@@ -197,7 +197,7 @@ func TestAfterDoFlowErr(t *testing.T) {
 
 func TestAfterDoFlow(t *testing.T) {
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	_, manager := NewMockFlowManager(call, nil)
 
 	manager.AfterDo = func(ctx context.Context, manager *Manager, store references.Store) (context.Context, error) {
@@ -217,7 +217,7 @@ func TestAfterDoFlow(t *testing.T) {
 
 func TestBeforeRollbackFlow(t *testing.T) {
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	nodes, manager := NewMockFlowManager(call, nil)
 
 	manager.BeforeRollback = func(ctx context.Context, manager *Manager, store references.Store) (context.Context, error) {
@@ -236,7 +236,7 @@ func TestBeforeRollbackFlow(t *testing.T) {
 func TestBeforeRollbackFlowErr(t *testing.T) {
 	expected := errors.New("unexpected error")
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	nodes, manager := NewMockFlowManager(call, nil)
 
 	manager.BeforeRollback = func(ctx context.Context, manager *Manager, store references.Store) (context.Context, error) {
@@ -254,7 +254,7 @@ func TestBeforeRollbackFlowErr(t *testing.T) {
 
 func TestAfterRollbackFlow(t *testing.T) {
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	nodes, manager := NewMockFlowManager(call, nil)
 
 	manager.AfterRollback = func(ctx context.Context, manager *Manager, store references.Store) (context.Context, error) {
@@ -273,7 +273,7 @@ func TestAfterRollbackFlow(t *testing.T) {
 func TestAfterRollbackFlowErr(t *testing.T) {
 	expected := errors.New("unexpected error")
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	nodes, manager := NewMockFlowManager(call, nil)
 
 	manager.AfterRollback = func(ctx context.Context, manager *Manager, store references.Store) (context.Context, error) {
@@ -427,7 +427,7 @@ func TestAfterManagerFunctionsError(t *testing.T) {
 }
 
 func TestErrorHandlers(t *testing.T) {
-	caller := &caller{}
+	caller := &mocker{}
 	nodes, manager := NewMockFlowManager(caller, nil)
 
 	expected := len(nodes) + 1 // expect nodes and flow error handler
@@ -438,7 +438,7 @@ func TestErrorHandlers(t *testing.T) {
 }
 
 func TestManagerName(t *testing.T) {
-	caller := &caller{}
+	caller := &mocker{}
 	_, manager := NewMockFlowManager(caller, nil)
 
 	expected := "mock"

--- a/pkg/flow/node.go
+++ b/pkg/flow/node.go
@@ -60,7 +60,7 @@ func WithNodeMiddleware(middleware *NodeMiddleware) NodeOption {
 	}
 }
 
-// NewNodeOptions constructs a new node options object and collects the options.
+// NewNodeOptions constructs a new node options object and collects the options
 func NewNodeOptions(opts ...NodeOption) NodeOptions {
 	options := NodeOptions{
 		middleware: &NodeMiddleware{},

--- a/pkg/flow/node.go
+++ b/pkg/flow/node.go
@@ -102,7 +102,7 @@ type Node struct {
 	Previous     Nodes
 	Call         Call
 	Revert       Call
-	DependsOn    map[string]*specs.Node
+	DependsOn    specs.Dependencies
 	References   map[string]*specs.PropertyReference
 	Next         Nodes
 	OnError      specs.ErrorHandle

--- a/pkg/flow/node.go
+++ b/pkg/flow/node.go
@@ -86,18 +86,6 @@ func NewNode(parent *broker.Context, node *specs.Node, opts ...NodeOption) *Node
 		refs.MergeLeft(references.ParameterReferences(node.Call.Request))
 	}
 
-	if options.call != nil {
-		for _, prop := range options.call.References() {
-			refs.MergeLeft(references.PropertyReferences(prop))
-		}
-	}
-
-	if options.rollback != nil {
-		for _, prop := range options.rollback.References() {
-			refs.MergeLeft(references.PropertyReferences(prop))
-		}
-	}
-
 	return &Node{
 		NodeMiddleware: options.middleware,
 		Condition:      options.condition,

--- a/pkg/flow/node_test.go
+++ b/pkg/flow/node_test.go
@@ -210,7 +210,7 @@ func BenchmarkSingleNodeCallingJSONCodecSerial(b *testing.B) {
 }
 
 func BenchmarkSingleNodeCallingParallel(b *testing.B) {
-	caller := &caller{}
+	caller := &mocker{}
 	node := NewMockNode("first", caller, nil)
 
 	b.ReportAllocs()
@@ -229,7 +229,7 @@ func BenchmarkSingleNodeCallingParallel(b *testing.B) {
 }
 
 func BenchmarkSingleNodeCallingSerial(b *testing.B) {
-	caller := &caller{}
+	caller := &mocker{}
 	node := NewMockNode("first", caller, nil)
 
 	b.ReportAllocs()
@@ -246,7 +246,7 @@ func BenchmarkSingleNodeCallingSerial(b *testing.B) {
 }
 
 func BenchmarkBranchedNodeCallingParallel(b *testing.B) {
-	caller := &caller{}
+	caller := &mocker{}
 	nodes := []*Node{
 		NewMockNode("first", caller, nil),
 		NewMockNode("second", caller, nil),
@@ -274,7 +274,7 @@ func BenchmarkBranchedNodeCallingParallel(b *testing.B) {
 }
 
 func BenchmarkBranchedNodeCallingSerial(b *testing.B) {
-	caller := &caller{}
+	caller := &mocker{}
 	nodes := []*Node{
 		NewMockNode("first", caller, nil),
 		NewMockNode("second", caller, nil),
@@ -374,8 +374,8 @@ func TestConstructingNode(t *testing.T) {
 
 func TestConstructingNodeReferences(t *testing.T) {
 	ctx := logger.WithLogger(broker.NewContext())
-	call := &caller{}
-	rollback := &caller{}
+	call := &mocker{}
+	rollback := &mocker{}
 
 	node := &specs.Node{
 		ID: "mock",
@@ -403,7 +403,7 @@ func TestNodeHas(t *testing.T) {
 }
 
 func TestNodeCalling(t *testing.T) {
-	caller := &caller{}
+	caller := &mocker{}
 
 	nodes := []*Node{
 		NewMockNode("first", caller, nil),
@@ -433,9 +433,9 @@ func TestNodeCalling(t *testing.T) {
 }
 
 func TestSlowNodeAbortingOnErr(t *testing.T) {
-	slow := &caller{name: "slow"}
-	failed := &caller{name: "failed", Err: errors.New("unexpected")}
-	caller := &caller{}
+	slow := &mocker{name: "slow"}
+	failed := &mocker{name: "failed", Err: errors.New("unexpected")}
+	caller := &mocker{}
 
 	nodes := []*Node{
 		NewMockNode("first", caller, nil),
@@ -478,7 +478,7 @@ func TestSlowNodeAbortingOnErr(t *testing.T) {
 }
 
 func TestNodeRevert(t *testing.T) {
-	rollback := &caller{}
+	rollback := &mocker{}
 
 	nodes := []*Node{
 		NewMockNode("first", nil, rollback),
@@ -508,7 +508,7 @@ func TestNodeRevert(t *testing.T) {
 }
 
 func TestNodeBranchesCalling(t *testing.T) {
-	caller := &caller{}
+	caller := &mocker{}
 
 	nodes := []*Node{
 		NewMockNode("first", caller, nil),
@@ -544,7 +544,7 @@ func TestNodeBranchesCalling(t *testing.T) {
 
 func TestBeforeDoNode(t *testing.T) {
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	node := NewMockNode("mock", call, nil)
 
 	node.BeforeDo = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
@@ -566,7 +566,7 @@ func TestBeforeDoNode(t *testing.T) {
 func TestBeforeDoNodeErr(t *testing.T) {
 	expected := errors.New("unexpected err")
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	node := NewMockNode("mock", call, nil)
 
 	node.BeforeDo = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
@@ -587,7 +587,7 @@ func TestBeforeDoNodeErr(t *testing.T) {
 
 func TestAfterDoNode(t *testing.T) {
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	node := NewMockNode("mock", call, nil)
 
 	node.AfterDo = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
@@ -609,7 +609,7 @@ func TestAfterDoNode(t *testing.T) {
 func TestAfterDoNodeErr(t *testing.T) {
 	expected := errors.New("unexpected err")
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	node := NewMockNode("mock", call, nil)
 
 	node.AfterDo = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
@@ -630,7 +630,7 @@ func TestAfterDoNodeErr(t *testing.T) {
 
 func TestBeforeRevertNode(t *testing.T) {
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	node := NewMockNode("mock", call, nil)
 
 	node.BeforeRollback = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
@@ -652,7 +652,7 @@ func TestBeforeRevertNode(t *testing.T) {
 func TestBeforeRevertNodeErr(t *testing.T) {
 	expected := errors.New("unexpected err")
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	node := NewMockNode("mock", call, nil)
 
 	node.BeforeRollback = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
@@ -673,7 +673,7 @@ func TestBeforeRevertNodeErr(t *testing.T) {
 
 func TestAfterRevertNode(t *testing.T) {
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	node := NewMockNode("mock", call, nil)
 
 	node.AfterRollback = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
@@ -695,7 +695,7 @@ func TestAfterRevertNode(t *testing.T) {
 func TestAfterRevertNodeErr(t *testing.T) {
 	expected := errors.New("unexpected err")
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	node := NewMockNode("mock", call, nil)
 
 	node.AfterRollback = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
@@ -716,7 +716,7 @@ func TestAfterRevertNodeErr(t *testing.T) {
 
 func TestNodeDoFunctions(t *testing.T) {
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	node := NewMockNode("mock", call, nil)
 
 	node.Functions = functions.Stack{
@@ -742,7 +742,7 @@ func TestNodeDoFunctions(t *testing.T) {
 func TestNodeDoFunctionsErr(t *testing.T) {
 	expected := errors.New("unexpected err")
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	node := NewMockNode("mock", call, nil)
 
 	node.Functions = functions.Stack{
@@ -767,7 +767,7 @@ func TestNodeDoFunctionsErr(t *testing.T) {
 
 func TestNodeDoConditionFunctions(t *testing.T) {
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	node := NewMockNode("mock", call, nil)
 
 	node.Condition = &Condition{
@@ -795,7 +795,7 @@ func TestNodeDoConditionFunctions(t *testing.T) {
 func TestNodeDoConditionFunctionsErr(t *testing.T) {
 	expected := errors.New("unexpected err")
 	counter := 0
-	call := &caller{}
+	call := &mocker{}
 	node := NewMockNode("mock", call, nil)
 
 	node.Condition = &Condition{

--- a/pkg/flow/node_test.go
+++ b/pkg/flow/node_test.go
@@ -114,8 +114,12 @@ func BenchmarkSingleNodeCallingJSONCodecParallel(b *testing.B) {
 	}
 
 	options := &CallOptions{
-		Request:  NewRequest(nil, req, nil),
-		Response: NewRequest(nil, res, nil),
+		Request: &Request{
+			Codec: req,
+		},
+		Response: &Request{
+			Codec: res,
+		},
 	}
 
 	call := NewCall(ctx, nil, options)
@@ -181,8 +185,12 @@ func BenchmarkSingleNodeCallingJSONCodecSerial(b *testing.B) {
 	}
 
 	options := &CallOptions{
-		Request:  NewRequest(nil, req, nil),
-		Response: NewRequest(nil, res, nil),
+		Request: &Request{
+			Codec: req,
+		},
+		Response: &Request{
+			Codec: res,
+		},
 	}
 
 	call := NewCall(ctx, nil, options)

--- a/pkg/flow/node_test.go
+++ b/pkg/flow/node_test.go
@@ -346,67 +346,13 @@ func TestConstructingNode(t *testing.T) {
 										Path:     "first",
 									},
 								},
+								"second": {
+									Reference: &specs.PropertyReference{
+										Resource: "input",
+										Path:     "first",
+									},
+								},
 							},
-						},
-					},
-				},
-			},
-			Call: &caller{
-				references: []*specs.Property{
-					{
-						Reference: &specs.PropertyReference{
-							Resource: "input",
-							Path:     "first",
-						},
-					},
-				},
-			},
-			Rollback: &caller{
-				references: []*specs.Property{
-					{
-						Reference: &specs.PropertyReference{
-							Resource: "input",
-							Path:     "first",
-						},
-					},
-				},
-			},
-		},
-		"call references": {
-			Expected: 2,
-			Node:     &specs.Node{},
-			Call: &caller{
-				references: []*specs.Property{
-					{
-						Reference: &specs.PropertyReference{
-							Resource: "input",
-							Path:     "first",
-						},
-					},
-					{
-						Reference: &specs.PropertyReference{
-							Resource: "input",
-							Path:     "second",
-						},
-					},
-				},
-			},
-		},
-		"rollback references": {
-			Expected: 2,
-			Node:     &specs.Node{},
-			Rollback: &caller{
-				references: []*specs.Property{
-					{
-						Reference: &specs.PropertyReference{
-							Resource: "input",
-							Path:     "first",
-						},
-					},
-					{
-						Reference: &specs.PropertyReference{
-							Resource: "input",
-							Path:     "second",
 						},
 					},
 				},

--- a/pkg/flow/node_test.go
+++ b/pkg/flow/node_test.go
@@ -408,7 +408,7 @@ func TestConstructingNode(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctx := logger.WithLogger(broker.NewContext())
-			result := NewNode(ctx, test.Node, nil, test.Call, test.Rollback, nil)
+			result := NewNode(ctx, test.Node, WithCall(test.Call), WithRollback(test.Rollback))
 
 			if len(result.References) != test.Expected {
 				t.Fatalf("unexpected amount of references %d, expected %d", len(result.References), test.Expected)
@@ -426,7 +426,7 @@ func TestConstructingNodeReferences(t *testing.T) {
 		ID: "mock",
 	}
 
-	result := NewNode(ctx, node, nil, call, rollback, nil)
+	result := NewNode(ctx, node, WithCall(call), WithRollback(rollback))
 	if result == nil {
 		t.Fatal("nil node returned")
 	}

--- a/pkg/flow/node_test.go
+++ b/pkg/flow/node_test.go
@@ -687,7 +687,7 @@ func TestBeforeRevertNode(t *testing.T) {
 	call := &caller{}
 	node := NewMockNode("mock", call, nil)
 
-	node.BeforeRevert = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
+	node.BeforeRollback = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
 		counter++
 		return ctx, nil
 	}
@@ -709,7 +709,7 @@ func TestBeforeRevertNodeErr(t *testing.T) {
 	call := &caller{}
 	node := NewMockNode("mock", call, nil)
 
-	node.BeforeRevert = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
+	node.BeforeRollback = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
 		counter++
 		return ctx, expected
 	}
@@ -730,7 +730,7 @@ func TestAfterRevertNode(t *testing.T) {
 	call := &caller{}
 	node := NewMockNode("mock", call, nil)
 
-	node.AfterRevert = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
+	node.AfterRollback = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
 		counter++
 		return ctx, nil
 	}
@@ -752,7 +752,7 @@ func TestAfterRevertNodeErr(t *testing.T) {
 	call := &caller{}
 	node := NewMockNode("mock", call, nil)
 
-	node.AfterRevert = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
+	node.AfterRollback = func(ctx context.Context, node *Node, tracker *Tracker, processes *Processes, store references.Store) (context.Context, error) {
 		counter++
 		return ctx, expected
 	}

--- a/pkg/functions/functions.go
+++ b/pkg/functions/functions.go
@@ -110,6 +110,14 @@ func PrepareFlowFunctions(ctx *broker.Context, mem Collection, functions Custom,
 
 // PrepareNodeFunctions prepares the available functions within the given node
 func PrepareNodeFunctions(ctx *broker.Context, mem Collection, functions Custom, flow specs.FlowInterface, node *specs.Node) (err error) {
+	if node.Intermediate != nil {
+		stack := mem.Reserve(node.Intermediate)
+		err = PrepareParameterMapFunctions(ctx, node, flow, stack, node.Intermediate, functions)
+		if err != nil {
+			return err
+		}
+	}
+
 	if node.Condition != nil {
 		stack := mem.Reserve(node.Condition.Params)
 		err = PrepareParameterMapFunctions(ctx, node, flow, stack, node.Condition.Params, functions)

--- a/pkg/functions/functions_test.go
+++ b/pkg/functions/functions_test.go
@@ -70,9 +70,9 @@ func TestCollectionReserve(t *testing.T) {
 		t.Fatalf("unexpected result %+v, expected %+v", result, expected)
 	}
 
-	unkown := collection.Reserve(&specs.ParameterMap{})
-	if len(unkown) != 0 {
-		t.Fatalf("unkown stack %+v, expected a empty stack", unkown)
+	unknown := collection.Reserve(&specs.ParameterMap{})
+	if len(unknown) != 0 {
+		t.Fatalf("unknown stack %+v, expected a empty stack", unknown)
 	}
 }
 

--- a/pkg/functions/functions_test.go
+++ b/pkg/functions/functions_test.go
@@ -132,7 +132,7 @@ func TestPrepareManifestFunctions(t *testing.T) {
 			collections: 3,
 			flows: specs.FlowListInterface{
 				&specs.Flow{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -185,7 +185,7 @@ func TestPrepareManifestFunctions(t *testing.T) {
 			collections: 2,
 			flows: specs.FlowListInterface{
 				&specs.Flow{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Rollback: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -239,7 +239,7 @@ func TestPrepareManifestFunctions(t *testing.T) {
 			collections: 2,
 			flows: specs.FlowListInterface{
 				&specs.Flow{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -271,7 +271,7 @@ func TestPrepareManifestFunctions(t *testing.T) {
 			collections: 2,
 			flows: specs.FlowListInterface{
 				&specs.Proxy{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -311,7 +311,7 @@ func TestPrepareManifestFunctions(t *testing.T) {
 			collections: 2,
 			flows: specs.FlowListInterface{
 				&specs.Proxy{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Rollback: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -365,7 +365,7 @@ func TestPrepareManifestFunctions(t *testing.T) {
 			collections: 2,
 			flows: specs.FlowListInterface{
 				&specs.Proxy{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -399,7 +399,7 @@ func TestPrepareManifestFunctions(t *testing.T) {
 			collections: 1,
 			flows: specs.FlowListInterface{
 				&specs.Proxy{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -418,7 +418,7 @@ func TestPrepareManifestFunctions(t *testing.T) {
 			collections: 1,
 			flows: specs.FlowListInterface{
 				&specs.Proxy{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Response: &specs.ParameterMap{
@@ -437,7 +437,7 @@ func TestPrepareManifestFunctions(t *testing.T) {
 			collections: 1,
 			flows: specs.FlowListInterface{
 				&specs.Proxy{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -454,7 +454,7 @@ func TestPrepareManifestFunctions(t *testing.T) {
 			collections: 1,
 			flows: specs.FlowListInterface{
 				&specs.Proxy{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Response: &specs.ParameterMap{
@@ -471,7 +471,7 @@ func TestPrepareManifestFunctions(t *testing.T) {
 			collections: 1,
 			flows: specs.FlowListInterface{
 				&specs.Proxy{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Condition: &specs.Condition{
 								Params: &specs.ParameterMap{
@@ -498,7 +498,7 @@ func TestPrepareManifestFunctions(t *testing.T) {
 			collections: 1,
 			flows: specs.FlowListInterface{
 				&specs.Flow{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Response: &specs.ParameterMap{
@@ -557,7 +557,7 @@ func TestPrepareManifestFunctionsErr(t *testing.T) {
 			collections: 3,
 			flows: specs.FlowListInterface{
 				&specs.Flow{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -610,7 +610,7 @@ func TestPrepareManifestFunctionsErr(t *testing.T) {
 			collections: 2,
 			flows: specs.FlowListInterface{
 				&specs.Flow{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Rollback: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -664,7 +664,7 @@ func TestPrepareManifestFunctionsErr(t *testing.T) {
 			collections: 2,
 			flows: specs.FlowListInterface{
 				&specs.Flow{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -696,7 +696,7 @@ func TestPrepareManifestFunctionsErr(t *testing.T) {
 			collections: 2,
 			flows: specs.FlowListInterface{
 				&specs.Proxy{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -736,7 +736,7 @@ func TestPrepareManifestFunctionsErr(t *testing.T) {
 			collections: 2,
 			flows: specs.FlowListInterface{
 				&specs.Proxy{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Rollback: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -790,7 +790,7 @@ func TestPrepareManifestFunctionsErr(t *testing.T) {
 			collections: 2,
 			flows: specs.FlowListInterface{
 				&specs.Proxy{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -824,7 +824,7 @@ func TestPrepareManifestFunctionsErr(t *testing.T) {
 			collections: 1,
 			flows: specs.FlowListInterface{
 				&specs.Flow{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Condition: &specs.Condition{
 								Params: &specs.ParameterMap{
@@ -851,7 +851,7 @@ func TestPrepareManifestFunctionsErr(t *testing.T) {
 			collections: 1,
 			flows: specs.FlowListInterface{
 				&specs.Flow{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Response: &specs.ParameterMap{
@@ -874,7 +874,7 @@ func TestPrepareManifestFunctionsErr(t *testing.T) {
 			collections: 1,
 			flows: specs.FlowListInterface{
 				&specs.Flow{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Response: &specs.ParameterMap{

--- a/pkg/functions/references_test.go
+++ b/pkg/functions/references_test.go
@@ -38,7 +38,7 @@ func TestDefineFunction(t *testing.T) {
 				ID: "second",
 			},
 			flow: &specs.Flow{
-				Nodes: []*specs.Node{
+				Nodes: specs.NodeList{
 					{
 						ID: "first",
 						Call: &specs.Call{
@@ -79,7 +79,7 @@ func TestDefineFunction(t *testing.T) {
 				ID: "second",
 			},
 			flow: &specs.Flow{
-				Nodes: []*specs.Node{
+				Nodes: specs.NodeList{
 					{
 						ID: "first",
 						Call: &specs.Call{
@@ -109,7 +109,7 @@ func TestDefineFunction(t *testing.T) {
 			stack: nil,
 			node:  nil,
 			flow: &specs.Flow{
-				Nodes: []*specs.Node{},
+				Nodes: specs.NodeList{},
 			},
 		},
 	}

--- a/pkg/lookup/lookup.go
+++ b/pkg/lookup/lookup.go
@@ -89,6 +89,10 @@ func GetAvailableResources(flow specs.FlowInterface, breakpoint string) map[stri
 	for _, node := range flow.GetNodes() {
 		references[node.ID] = ReferenceMap{}
 		if node.Call != nil {
+			if node.Intermediate != nil {
+				references[node.ID][template.ResponseResource] = PropertyLookup(node.Intermediate)
+			}
+
 			if node.Call.Request != nil {
 				if node.Call.Request.Stack != nil {
 					for key, returns := range node.Call.Request.Stack {

--- a/pkg/lookup/lookup.go
+++ b/pkg/lookup/lookup.go
@@ -90,7 +90,7 @@ func GetAvailableResources(flow specs.FlowInterface, breakpoint string) map[stri
 		references[node.ID] = ReferenceMap{}
 		if node.Call != nil {
 			if node.Intermediate != nil {
-				references[node.ID][template.ResponseResource] = PropertyLookup(node.Intermediate)
+				references[node.ID][template.ResponseResource] = PropertyLookup(node.Intermediate.Property)
 			}
 
 			if node.Call.Request != nil {

--- a/pkg/lookup/lookup.go
+++ b/pkg/lookup/lookup.go
@@ -88,11 +88,19 @@ func GetAvailableResources(flow specs.FlowInterface, breakpoint string) map[stri
 
 	for _, node := range flow.GetNodes() {
 		references[node.ID] = ReferenceMap{}
-		if node.Call != nil {
-			if node.Intermediate != nil {
-				references[node.ID][template.ResponseResource] = PropertyLookup(node.Intermediate.Property)
+
+		if node.Intermediate != nil {
+			if node.Intermediate.Stack != nil {
+				for key, returns := range node.Intermediate.Stack {
+					references[template.StackResource][key] = PropertyLookup(returns)
+				}
 			}
 
+			references[node.ID][template.ResponseResource] = PropertyLookup(node.Intermediate.Property)
+			references[node.ID][template.HeaderResource] = VariableHeaderLookup(node.Intermediate.Header)
+		}
+
+		if node.Call != nil {
 			if node.Call.Request != nil {
 				if node.Call.Request.Stack != nil {
 					for key, returns := range node.Call.Request.Stack {

--- a/pkg/lookup/lookup_test.go
+++ b/pkg/lookup/lookup_test.go
@@ -59,7 +59,7 @@ func TestGetNextResource(t *testing.T) {
 			breakpoint: "first",
 			expected:   "second",
 			manager: &specs.Flow{
-				Nodes: []*specs.Node{
+				Nodes: specs.NodeList{
 					{
 						ID: "first",
 					},
@@ -73,7 +73,7 @@ func TestGetNextResource(t *testing.T) {
 			breakpoint: "second",
 			expected:   "third",
 			manager: &specs.Flow{
-				Nodes: []*specs.Node{
+				Nodes: specs.NodeList{
 					{
 						ID: "first",
 					},
@@ -90,7 +90,7 @@ func TestGetNextResource(t *testing.T) {
 			breakpoint: "last",
 			expected:   template.OutputResource,
 			manager: &specs.Flow{
-				Nodes: []*specs.Node{
+				Nodes: specs.NodeList{
 					{
 						ID: "first",
 					},
@@ -104,7 +104,7 @@ func TestGetNextResource(t *testing.T) {
 			breakpoint: "unknown",
 			expected:   "unknown",
 			manager: &specs.Flow{
-				Nodes: []*specs.Node{
+				Nodes: specs.NodeList{
 					{
 						ID: "first",
 					},
@@ -444,7 +444,7 @@ func NewMockFlow(name string) *specs.Flow {
 		Input: &specs.ParameterMap{
 			Property: NewInputMockProperty(),
 		},
-		Nodes: []*specs.Node{
+		Nodes: specs.NodeList{
 			NewMockCall("first"),
 			NewMockCall("second"),
 			NewMockCall("third"),

--- a/pkg/providers/hcl/specs.go
+++ b/pkg/providers/hcl/specs.go
@@ -725,10 +725,12 @@ func ParseIntermediateResources(ctx *broker.Context, dependencies specs.Dependen
 		}
 
 		node := &specs.Node{
-			Type:         specs.NodeIntermediate,
-			DependsOn:    DependenciesExcept(dependencies, prop.Name),
-			ID:           prop.Name,
-			Intermediate: prop,
+			Type:      specs.NodeIntermediate,
+			DependsOn: DependenciesExcept(dependencies, prop.Name),
+			ID:        prop.Name,
+			Intermediate: &specs.ParameterMap{
+				Property: prop,
+			},
 		}
 
 		nodes = append(nodes, node)

--- a/pkg/providers/hcl/specs.go
+++ b/pkg/providers/hcl/specs.go
@@ -725,14 +725,10 @@ func ParseIntermediateResources(ctx *broker.Context, dependencies map[string]*sp
 		}
 
 		node := &specs.Node{
-			Type:      specs.NodeIntermediate,
-			DependsOn: DependenciesExcept(dependencies, prop.Name),
-			ID:        prop.Name,
-			Call: &specs.Call{
-				Response: &specs.ParameterMap{
-					Property: prop,
-				},
-			},
+			Type:         specs.NodeIntermediate,
+			DependsOn:    DependenciesExcept(dependencies, prop.Name),
+			ID:           prop.Name,
+			Intermediate: prop,
 		}
 
 		nodes = append(nodes, node)

--- a/pkg/providers/hcl/specs.go
+++ b/pkg/providers/hcl/specs.go
@@ -752,7 +752,7 @@ func ParseIntermediateCondition(ctx *broker.Context, dependencies map[string]*sp
 		Condition: expr,
 	}
 
-	result := []*specs.Node{expression}
+	result := specs.NodeList{expression}
 
 	for _, references := range condition.References {
 		nodes, err := ParseIntermediateResources(ctx, dependencies, references)

--- a/pkg/providers/hcl/specs.go
+++ b/pkg/providers/hcl/specs.go
@@ -114,7 +114,7 @@ func ParseIntermediateFlow(ctx *broker.Context, flow Flow) (*specs.Flow, error) 
 		result.OnError.Response = spec
 	}
 
-	var before map[string]*specs.Node
+	var before specs.Dependencies
 	if flow.Before != nil {
 		dependencies, references, resources := ParseIntermediateBefore(ctx, flow.Before)
 		before = dependencies
@@ -154,8 +154,8 @@ func ParseIntermediateFlow(ctx *broker.Context, flow Flow) (*specs.Flow, error) 
 }
 
 // DependenciesExcept copies the given dependencies except the given resource
-func DependenciesExcept(dependencies map[string]*specs.Node, resource string) map[string]*specs.Node {
-	result := map[string]*specs.Node{}
+func DependenciesExcept(dependencies specs.Dependencies, resource string) specs.Dependencies {
+	result := specs.Dependencies{}
 	for key, val := range dependencies {
 		if key == resource {
 			continue
@@ -256,7 +256,7 @@ func ParseIntermediateProxy(ctx *broker.Context, proxy Proxy) (*specs.Proxy, err
 		result.OnError.Response = spec
 	}
 
-	var before map[string]*specs.Node
+	var before specs.Dependencies
 	if proxy.Before != nil {
 		dependencies, references, resources := ParseIntermediateBefore(ctx, proxy.Before)
 		before = dependencies
@@ -518,7 +518,7 @@ func ParseIntermediateParameters(ctx *broker.Context, options hcl.Body) (map[str
 }
 
 // ParseIntermediateNode parses the given intermediate call to a spec call
-func ParseIntermediateNode(ctx *broker.Context, dependencies map[string]*specs.Node, node Resource) (*specs.Node, error) {
+func ParseIntermediateNode(ctx *broker.Context, dependencies specs.Dependencies, node Resource) (*specs.Node, error) {
 	call, err := ParseIntermediateCall(ctx, node.Request)
 	if err != nil {
 		return nil, err
@@ -531,7 +531,7 @@ func ParseIntermediateNode(ctx *broker.Context, dependencies map[string]*specs.N
 
 	result := specs.Node{
 		Type:         specs.NodeIntermediate,
-		DependsOn:    make(map[string]*specs.Node, len(node.DependsOn)),
+		DependsOn:    make(specs.Dependencies, len(node.DependsOn)),
 		ID:           node.Name,
 		Name:         node.Name,
 		Call:         call,
@@ -693,8 +693,8 @@ func ParseIntermediateProperty(ctx *broker.Context, path string, property *hcl.A
 }
 
 // ParseIntermediateBefore parses the given before into a collection of dependencies
-func ParseIntermediateBefore(ctx *broker.Context, before *Before) (dependencies map[string]*specs.Node, references []Resources, resources []Resource) {
-	result := make(map[string]*specs.Node)
+func ParseIntermediateBefore(ctx *broker.Context, before *Before) (dependencies specs.Dependencies, references []Resources, resources []Resource) {
+	result := make(specs.Dependencies)
 
 	for _, resources := range before.References {
 		attrs, _ := resources.Properties.JustAttributes()
@@ -714,7 +714,7 @@ func ParseIntermediateBefore(ctx *broker.Context, before *Before) (dependencies 
 }
 
 // ParseIntermediateResources parses the given resources to nodes
-func ParseIntermediateResources(ctx *broker.Context, dependencies map[string]*specs.Node, resources Resources) ([]*specs.Node, error) {
+func ParseIntermediateResources(ctx *broker.Context, dependencies specs.Dependencies, resources Resources) ([]*specs.Node, error) {
 	attrs, _ := resources.Properties.JustAttributes()
 	nodes := make([]*specs.Node, 0, len(attrs))
 
@@ -738,7 +738,7 @@ func ParseIntermediateResources(ctx *broker.Context, dependencies map[string]*sp
 }
 
 // ParseIntermediateCondition parses the given intermediate condition and returns the compiled nodes
-func ParseIntermediateCondition(ctx *broker.Context, dependencies map[string]*specs.Node, condition Condition) ([]*specs.Node, error) {
+func ParseIntermediateCondition(ctx *broker.Context, dependencies specs.Dependencies, condition Condition) ([]*specs.Node, error) {
 	expr, err := conditions.NewEvaluableExpression(ctx, condition.Expression)
 	if err != nil {
 		return nil, err
@@ -748,7 +748,7 @@ func ParseIntermediateCondition(ctx *broker.Context, dependencies map[string]*sp
 		Type:      specs.NodeCondition,
 		ID:        condition.Expression,
 		Name:      "condition",
-		DependsOn: map[string]*specs.Node{},
+		DependsOn: specs.Dependencies{},
 		Condition: expr,
 	}
 

--- a/pkg/providers/schemas_test.go
+++ b/pkg/providers/schemas_test.go
@@ -23,9 +23,9 @@ func NewMockServices() specs.ServiceList {
 					Output: "com.mock.message",
 				},
 				{
-					Name:   "unkown",
-					Input:  "com.mock.unkown",
-					Output: "com.mock.unkown",
+					Name:   "unknown",
+					Input:  "com.mock.unknown",
+					Output: "com.mock.unknown",
 				},
 			},
 		},
@@ -194,21 +194,21 @@ func TestDefineSchemas(t *testing.T) {
 	}
 }
 
-func TestDefineSchemasUnkown(t *testing.T) {
+func TestDefineSchemasUnknown(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]specs.FlowListInterface{
 		"input": {
 			&specs.Flow{
 				Input: &specs.ParameterMap{
-					Schema: "com.mock.unkown",
+					Schema: "com.mock.unknown",
 				},
 			},
 		},
 		"output": {
 			&specs.Flow{
 				Output: &specs.ParameterMap{
-					Schema: "com.mock.unkown",
+					Schema: "com.mock.unknown",
 				},
 			},
 		},
@@ -218,7 +218,7 @@ func TestDefineSchemasUnkown(t *testing.T) {
 					&specs.Node{
 						Call: &specs.Call{
 							Request: &specs.ParameterMap{
-								Schema: "com.mock.unkown",
+								Schema: "com.mock.unknown",
 							},
 						},
 					},
@@ -231,7 +231,7 @@ func TestDefineSchemasUnkown(t *testing.T) {
 					&specs.Node{
 						Call: &specs.Call{
 							Response: &specs.ParameterMap{
-								Schema: "com.mock.unkown",
+								Schema: "com.mock.unknown",
 							},
 						},
 					},
@@ -272,7 +272,7 @@ func TestDefineSchemasUnkown(t *testing.T) {
 					&specs.Node{
 						Call: &specs.Call{
 							Service:  "com.mock.greeter",
-							Method:   "unkown",
+							Method:   "unknown",
 							Request:  &specs.ParameterMap{},
 							Response: &specs.ParameterMap{},
 						},
@@ -286,7 +286,7 @@ func TestDefineSchemasUnkown(t *testing.T) {
 					&specs.Node{
 						OnError: &specs.OnError{
 							Response: &specs.ParameterMap{
-								Schema: "com.mock.unkown",
+								Schema: "com.mock.unknown",
 							},
 						},
 					},
@@ -299,7 +299,7 @@ func TestDefineSchemasUnkown(t *testing.T) {
 					&specs.Node{
 						Condition: &specs.Condition{
 							Params: &specs.ParameterMap{
-								Schema: "com.mock.unkown",
+								Schema: "com.mock.unknown",
 							},
 						},
 					},
@@ -312,7 +312,7 @@ func TestDefineSchemasUnkown(t *testing.T) {
 					&specs.Node{
 						Rollback: &specs.Call{
 							Request: &specs.ParameterMap{
-								Schema: "com.mock.unkown",
+								Schema: "com.mock.unknown",
 							},
 						},
 					},
@@ -325,7 +325,7 @@ func TestDefineSchemasUnkown(t *testing.T) {
 					&specs.Node{
 						Rollback: &specs.Call{
 							Response: &specs.ParameterMap{
-								Schema: "com.mock.unkown",
+								Schema: "com.mock.unknown",
 							},
 						},
 					},
@@ -336,7 +336,7 @@ func TestDefineSchemasUnkown(t *testing.T) {
 			&specs.Flow{
 				OnError: &specs.OnError{
 					Response: &specs.ParameterMap{
-						Schema: "com.mock.unkown",
+						Schema: "com.mock.unknown",
 					},
 				},
 			},

--- a/pkg/references/forwarding/references.go
+++ b/pkg/references/forwarding/references.go
@@ -23,7 +23,7 @@ func ResolveReferences(ctx *broker.Context, flows specs.FlowListInterface) {
 		}
 
 		// Error and output dependencies could safely be ignored
-		empty := map[string]*specs.Node{}
+		empty := specs.Dependencies{}
 
 		if flow.GetOnError() != nil {
 			ResolveOnError(flow.GetOnError(), empty)
@@ -39,7 +39,7 @@ func ResolveReferences(ctx *broker.Context, flows specs.FlowListInterface) {
 // ResolveNodeReferences resolves the node references found inside the request and response property
 func ResolveNodeReferences(node *specs.Node) {
 	if node.DependsOn == nil {
-		node.DependsOn = map[string]*specs.Node{}
+		node.DependsOn = specs.Dependencies{}
 	}
 
 	if node.OnError != nil {
@@ -62,7 +62,7 @@ func ResolveNodeReferences(node *specs.Node) {
 }
 
 // ResolveParameterMap resolves the params inside the given parameter map
-func ResolveParameterMap(parameters *specs.ParameterMap, dependencies map[string]*specs.Node) {
+func ResolveParameterMap(parameters *specs.ParameterMap, dependencies specs.Dependencies) {
 	if parameters == nil {
 		return
 	}
@@ -73,7 +73,7 @@ func ResolveParameterMap(parameters *specs.ParameterMap, dependencies map[string
 }
 
 // ResolveOnError resolves the params inside the given parameter map
-func ResolveOnError(parameters *specs.OnError, dependencies map[string]*specs.Node) {
+func ResolveOnError(parameters *specs.OnError, dependencies specs.Dependencies) {
 	if parameters == nil {
 		return
 	}
@@ -86,7 +86,7 @@ func ResolveOnError(parameters *specs.OnError, dependencies map[string]*specs.No
 }
 
 // ResolveParamReferences resolves all nested references made inside the given params
-func ResolveParamReferences(params map[string]*specs.Property, dependencies map[string]*specs.Node) {
+func ResolveParamReferences(params map[string]*specs.Property, dependencies specs.Dependencies) {
 	if params == nil {
 		return
 	}
@@ -97,7 +97,7 @@ func ResolveParamReferences(params map[string]*specs.Property, dependencies map[
 }
 
 // ResolveFunctionsReferences resolves all references made inside the given function arguments and return value
-func ResolveFunctionsReferences(functions functions.Stack, dependencies map[string]*specs.Node) {
+func ResolveFunctionsReferences(functions functions.Stack, dependencies specs.Dependencies) {
 	if functions == nil {
 		return
 	}
@@ -114,14 +114,14 @@ func ResolveFunctionsReferences(functions functions.Stack, dependencies map[stri
 }
 
 // ResolveHeaderReferences resolves all references made inside the header
-func ResolveHeaderReferences(header specs.Header, dependencies map[string]*specs.Node) {
+func ResolveHeaderReferences(header specs.Header, dependencies specs.Dependencies) {
 	for _, prop := range header {
 		ResolvePropertyReferences(prop, dependencies)
 	}
 }
 
 // ResolvePropertyReferences moves any property reference into the correct data structure
-func ResolvePropertyReferences(property *specs.Property, dependencies map[string]*specs.Node) {
+func ResolvePropertyReferences(property *specs.Property, dependencies specs.Dependencies) {
 	if property == nil {
 		return
 	}

--- a/pkg/references/forwarding/references_test.go
+++ b/pkg/references/forwarding/references_test.go
@@ -28,7 +28,7 @@ func TestResolveReferences(t *testing.T) {
 
 			flows := specs.FlowListInterface{
 				&specs.Flow{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -60,7 +60,7 @@ func TestResolveReferences(t *testing.T) {
 
 			flows := specs.FlowListInterface{
 				&specs.Proxy{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Request: &specs.ParameterMap{
@@ -92,7 +92,7 @@ func TestResolveReferences(t *testing.T) {
 
 			flows := specs.FlowListInterface{
 				&specs.Flow{
-					Nodes: []*specs.Node{
+					Nodes: specs.NodeList{
 						{
 							Call: &specs.Call{
 								Request: &specs.ParameterMap{

--- a/pkg/references/store.go
+++ b/pkg/references/store.go
@@ -239,11 +239,11 @@ func (prefix *PrefixStore) StoreEnum(resource string, path string, enum int32) {
 	prefix.store.StoreEnum(prefix.resource, template.JoinPath(prefix.path, path), enum)
 }
 
-// References represents a map of property references
-type References map[string]*specs.PropertyReference
+// Collection represents a map of property references
+type Collection map[string]*specs.PropertyReference
 
 // MergeLeft merges the references into the given reference
-func (references References) MergeLeft(incoming ...References) {
+func (references Collection) MergeLeft(incoming ...Collection) {
 	for _, refs := range incoming {
 		for key, val := range refs {
 			references[key] = val
@@ -252,11 +252,11 @@ func (references References) MergeLeft(incoming ...References) {
 }
 
 // ParameterReferences returns all the available references inside the given parameter map
-func ParameterReferences(params *specs.ParameterMap) References {
+func ParameterReferences(params *specs.ParameterMap) Collection {
 	result := make(map[string]*specs.PropertyReference)
 
 	if params == nil {
-		return References{}
+		return Collection{}
 	}
 
 	if params.Header != nil {
@@ -277,7 +277,7 @@ func ParameterReferences(params *specs.ParameterMap) References {
 }
 
 // PropertyReferences returns the available references within the given property
-func PropertyReferences(property *specs.Property) References {
+func PropertyReferences(property *specs.Property) Collection {
 	result := make(map[string]*specs.PropertyReference)
 
 	if property.Reference != nil {

--- a/pkg/references/store_test.go
+++ b/pkg/references/store_test.go
@@ -513,8 +513,8 @@ func TestMergeReferences(t *testing.T) {
 	resource := "input"
 	path := ""
 
-	left := References{}
-	right := References{
+	left := Collection{}
+	right := Collection{
 		key: &specs.PropertyReference{
 			Resource: resource,
 			Path:     path,

--- a/pkg/specs/flows.go
+++ b/pkg/specs/flows.go
@@ -224,6 +224,7 @@ type Node struct {
 	Type         NodeType         `json:"type,omitempty"`
 	ID           string           `json:"id,omitempty"`
 	Name         string           `json:"name,omitempty"`
+	Intermediate *Property        `json:"intermediate,omitempty"`
 	Condition    *Condition       `json:"condition,omitempty"`
 	DependsOn    map[string]*Node `json:"depends_on,omitempty"`
 	Call         *Call            `json:"call,omitempty"`

--- a/pkg/specs/flows.go
+++ b/pkg/specs/flows.go
@@ -224,16 +224,16 @@ type Dependencies map[string]*Node
 // A call could contain the request headers, request body, rollback, and the execution type.
 type Node struct {
 	*metadata.Meta
-	Type         NodeType     `json:"type,omitempty"`
-	ID           string       `json:"id,omitempty"`
-	Name         string       `json:"name,omitempty"`
-	Intermediate *Property    `json:"intermediate,omitempty"`
-	Condition    *Condition   `json:"condition,omitempty"`
-	DependsOn    Dependencies `json:"depends_on,omitempty"`
-	Call         *Call        `json:"call,omitempty"`
-	Rollback     *Call        `json:"rollback,omitempty"`
-	ExpectStatus []int        `json:"expect_status,omitempty"`
-	OnError      *OnError     `json:"on_error,omitempty"`
+	Type         NodeType      `json:"type,omitempty"`
+	ID           string        `json:"id,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Intermediate *ParameterMap `json:"intermediate,omitempty"`
+	Condition    *Condition    `json:"condition,omitempty"`
+	DependsOn    Dependencies  `json:"depends_on,omitempty"`
+	Call         *Call         `json:"call,omitempty"`
+	Rollback     *Call         `json:"rollback,omitempty"`
+	ExpectStatus []int         `json:"expect_status,omitempty"`
+	OnError      *OnError      `json:"on_error,omitempty"`
 }
 
 // GetOnError returns the error handling for the given node

--- a/pkg/specs/flows.go
+++ b/pkg/specs/flows.go
@@ -214,6 +214,9 @@ var (
 	NodeIntermediate NodeType = "intermediate"
 )
 
+// Dependencies represents a collection of node dependencies
+type Dependencies map[string]*Node
+
 // Node represents a point inside a given flow where a request or rollback could be preformed.
 // Nodes could be executed synchronously or asynchronously.
 // All calls are referencing a service method, the service should match the alias defined inside the service.
@@ -221,16 +224,16 @@ var (
 // A call could contain the request headers, request body, rollback, and the execution type.
 type Node struct {
 	*metadata.Meta
-	Type         NodeType         `json:"type,omitempty"`
-	ID           string           `json:"id,omitempty"`
-	Name         string           `json:"name,omitempty"`
-	Intermediate *Property        `json:"intermediate,omitempty"`
-	Condition    *Condition       `json:"condition,omitempty"`
-	DependsOn    map[string]*Node `json:"depends_on,omitempty"`
-	Call         *Call            `json:"call,omitempty"`
-	Rollback     *Call            `json:"rollback,omitempty"`
-	ExpectStatus []int            `json:"expect_status,omitempty"`
-	OnError      *OnError         `json:"on_error,omitempty"`
+	Type         NodeType     `json:"type,omitempty"`
+	ID           string       `json:"id,omitempty"`
+	Name         string       `json:"name,omitempty"`
+	Intermediate *Property    `json:"intermediate,omitempty"`
+	Condition    *Condition   `json:"condition,omitempty"`
+	DependsOn    Dependencies `json:"depends_on,omitempty"`
+	Call         *Call        `json:"call,omitempty"`
+	Rollback     *Call        `json:"rollback,omitempty"`
+	ExpectStatus []int        `json:"expect_status,omitempty"`
+	OnError      *OnError     `json:"on_error,omitempty"`
 }
 
 // GetOnError returns the error handling for the given node

--- a/pkg/specs/flows_test.go
+++ b/pkg/specs/flows_test.go
@@ -26,7 +26,7 @@ func TestFlowListInterfaceGet(t *testing.T) {
 	}
 }
 
-func TestFlowListInterfaceGetUnkown(t *testing.T) {
+func TestFlowListInterfaceGetUnknown(t *testing.T) {
 	flows := FlowListInterface{}
 	result := flows.Get("expected")
 
@@ -46,7 +46,7 @@ func TestFlowListGet(t *testing.T) {
 	}
 }
 
-func TestFlowListGetUnkown(t *testing.T) {
+func TestFlowListGetUnknown(t *testing.T) {
 	flows := FlowList{}
 	result := flows.Get("expected")
 
@@ -109,7 +109,7 @@ func TestProxyListGet(t *testing.T) {
 	}
 }
 
-func TestProxyListGetUnkown(t *testing.T) {
+func TestProxyListGetUnknown(t *testing.T) {
 	flows := ProxyList{}
 	result := flows.Get("expected")
 
@@ -181,9 +181,9 @@ func TestNodeListGet(t *testing.T) {
 	}
 }
 
-func TestNodeListGetUnkown(t *testing.T) {
+func TestNodeListGetUnknown(t *testing.T) {
 	nodes := &NodeList{&Node{ID: "first"}, &Node{ID: "second"}}
-	result := nodes.Get("unkown")
+	result := nodes.Get("unknown")
 	if result != nil {
 		t.Errorf("unexpected result %+v", result)
 	}

--- a/pkg/specs/property_test.go
+++ b/pkg/specs/property_test.go
@@ -106,7 +106,7 @@ func TestObjectsGet(t *testing.T) {
 
 func TestObjectsGetNilValue(t *testing.T) {
 	var objects Schemas
-	result := objects.Get("unkown")
+	result := objects.Get("unknown")
 	if result != nil {
 		t.Fatalf("unexpected result %+v", result)
 	}

--- a/pkg/specs/services_test.go
+++ b/pkg/specs/services_test.go
@@ -26,10 +26,10 @@ func TestServicesGet(t *testing.T) {
 	}
 }
 
-func TestServicesGetUnkown(t *testing.T) {
+func TestServicesGetUnknown(t *testing.T) {
 	services := ServiceList{&Service{FullyQualifiedName: "first"}}
 
-	result := services.Get("unkown")
+	result := services.Get("unknown")
 	if result != nil {
 		t.Fatalf("unexpected result %+v", result)
 	}
@@ -53,7 +53,7 @@ func TestServiceGetMethod(t *testing.T) {
 	}
 }
 
-func TestServiceGetUnkownMethod(t *testing.T) {
+func TestServiceGetUnknownMethod(t *testing.T) {
 	service := &Service{
 		Methods: []*Method{
 			{
@@ -62,7 +62,7 @@ func TestServiceGetUnkownMethod(t *testing.T) {
 		},
 	}
 
-	result := service.GetMethod("unkown")
+	result := service.GetMethod("unknown")
 	if result != nil {
 		t.Fatalf("unexpected result %+v", result)
 	}

--- a/pkg/specs/template/template_test.go
+++ b/pkg/specs/template/template_test.go
@@ -147,7 +147,7 @@ func TestParseReferenceErr(t *testing.T) {
 	}
 }
 
-func TestUnkownReferencePattern(t *testing.T) {
+func TestUnknownReferencePattern(t *testing.T) {
 	name := ""
 	path := "message"
 

--- a/pkg/transport/grpc/caller_test.go
+++ b/pkg/transport/grpc/caller_test.go
@@ -41,7 +41,7 @@ func TestCaller(t *testing.T) {
 	})
 
 	nodes := flow.Nodes{
-		flow.NewNode(ctx, node, nil, call, nil, nil),
+		flow.NewNode(ctx, node, flow.WithCall(call)),
 	}
 
 	listener, port := NewMockListener(t, nodes, nil)

--- a/pkg/transport/grpc/listener_test.go
+++ b/pkg/transport/grpc/listener_test.go
@@ -58,7 +58,7 @@ func TestListener(t *testing.T) {
 	})
 
 	nodes := flow.Nodes{
-		flow.NewNode(ctx, node, nil, call, nil, nil),
+		flow.NewNode(ctx, node, flow.WithCall(call)),
 	}
 
 	listener, port := NewMockListener(t, nodes, nil)
@@ -208,7 +208,7 @@ func TestErrorHandlingListener(t *testing.T) {
 			})
 
 			nodes := flow.Nodes{
-				flow.NewNode(ctx, node, nil, call, nil, nil),
+				flow.NewNode(ctx, node, flow.WithCall(call)),
 			}
 
 			obj := transport.NewObject(node.OnError.Response, node.OnError.Status, node.OnError.Message)

--- a/pkg/transport/http/listener_test.go
+++ b/pkg/transport/http/listener_test.go
@@ -73,7 +73,7 @@ func TestListener(t *testing.T) {
 	})
 
 	nodes := flow.Nodes{
-		flow.NewNode(ctx, node, nil, call, nil, nil),
+		flow.NewNode(ctx, node, flow.WithCall(call)),
 	}
 
 	listener, endpoint := NewMockListener(t, nodes, nil)
@@ -195,7 +195,7 @@ func TestStoringParams(t *testing.T) {
 	})
 
 	nodes := flow.Nodes{
-		flow.NewNode(ctx, node, nil, call, nil, nil),
+		flow.NewNode(ctx, node, flow.WithCall(call)),
 	}
 
 	listener, endpoint := NewMockListener(t, nodes, nil)
@@ -580,7 +580,7 @@ func TestListenerErrorHandling(t *testing.T) {
 			})
 
 			nodes := flow.Nodes{
-				flow.NewNode(ctx, node, nil, call, nil, nil),
+				flow.NewNode(ctx, node, flow.WithCall(call)),
 			}
 
 			obj := transport.NewObject(node.OnError.Response, node.OnError.Status, nil)


### PR DESCRIPTION
This PR refactors the specs introducing the intermediate property. This property allows other components such as conditions and references to avoid abusing the `specs.Call` implementation.