### PR TITLE
Catch panics thrown by julienschmidt/httprouter on route conflict

### DIFF
--- a/pkg/transport/http/errors.go
+++ b/pkg/transport/http/errors.go
@@ -1,0 +1,6 @@
+package http
+
+// ErrRouteConflict is returned when HTTP route conflict is detected.
+type ErrRouteConflict string
+
+func (e ErrRouteConflict) Error() string { return string(e) }


### PR DESCRIPTION
julienschmidt/httprouter panics when static route conflicts with dynamic one:
- `/foo`  and  `/:id`
- `/:resource/bar` and `/foo/bar`