### PR TITLE
include dependencies inside parameter map

### DIFF
--- a/pkg/broker/endpoints/transport.go
+++ b/pkg/broker/endpoints/transport.go
@@ -198,7 +198,7 @@ func service(ctx *broker.Context, manager specs.FlowInterface, node *specs.Node,
 			}
 
 			forwarding.ResolvePropertyReferences(reference, node.DependsOn)
-			err = dependencies.ResolveNode(manager, node, make(specs.Dependencies))
+			err = dependencies.Resolve(manager, node.DependsOn, node.ID, make(dependencies.Unresolved))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/broker/providers/providers.go
+++ b/pkg/broker/providers/providers.go
@@ -74,7 +74,7 @@ func Resolve(ctx *broker.Context, mem functions.Collection, options config.Optio
 		return Collection{}, err
 	}
 
-	forwarding.ResolveReferences(ctx, flows)
+	forwarding.ResolveReferences(ctx, flows, mem)
 
 	err = dependencies.ResolveFlows(ctx, flows)
 	if err != nil {

--- a/pkg/references/forwarding/references.go
+++ b/pkg/references/forwarding/references.go
@@ -27,8 +27,12 @@ func ResolveReferences(ctx *broker.Context, flows specs.FlowListInterface) {
 		}
 
 		if flow.GetOutput() != nil {
-			ResolveHeaderReferences(flow.GetOutput().Header, empty)
-			ResolvePropertyReferences(flow.GetOutput().Property, empty)
+			if flow.GetOutput().DependsOn == nil {
+				flow.GetOutput().DependsOn = specs.Dependencies{}
+			}
+
+			ResolveHeaderReferences(flow.GetOutput().Header, flow.GetOutput().DependsOn)
+			ResolvePropertyReferences(flow.GetOutput().Property, flow.GetOutput().DependsOn)
 		}
 	}
 }

--- a/pkg/references/forwarding/references.go
+++ b/pkg/references/forwarding/references.go
@@ -64,9 +64,17 @@ func ResolveParameterMap(parameters *specs.ParameterMap, dependencies specs.Depe
 		return
 	}
 
-	ResolveParamReferences(parameters.Params, dependencies)
-	ResolveHeaderReferences(parameters.Header, dependencies)
-	ResolvePropertyReferences(parameters.Property, dependencies)
+	if parameters.DependsOn == nil {
+		parameters.DependsOn = specs.Dependencies{}
+	}
+
+	ResolveParamReferences(parameters.Params, parameters.DependsOn)
+	ResolveHeaderReferences(parameters.Header, parameters.DependsOn)
+	ResolvePropertyReferences(parameters.Property, parameters.DependsOn)
+
+	for key, val := range parameters.DependsOn {
+		dependencies[key] = val
+	}
 }
 
 // ResolveOnError resolves the params inside the given parameter map

--- a/pkg/references/forwarding/references_test.go
+++ b/pkg/references/forwarding/references_test.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/jexia/semaphore/pkg/broker"
 	"github.com/jexia/semaphore/pkg/broker/logger"
+	"github.com/jexia/semaphore/pkg/functions"
 	"github.com/jexia/semaphore/pkg/specs"
 )
 
 func TestResolveReferences(t *testing.T) {
-	tests := map[string]func() (specs.FlowListInterface, *specs.Property, *specs.Property){
-		"flow": func() (specs.FlowListInterface, *specs.Property, *specs.Property) {
+	tests := map[string]func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection){
+		"flow": func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection) {
 			expected := &specs.Property{
 				Reference: &specs.PropertyReference{
 					Resource: "expected",
@@ -40,9 +41,339 @@ func TestResolveReferences(t *testing.T) {
 				},
 			}
 
-			return flows, target, expected
+			return flows, target, expected, functions.Collection{}
 		},
-		"proxy": func() (specs.FlowListInterface, *specs.Property, *specs.Property) {
+		"intermediate": func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection) {
+			expected := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "expected",
+					Path:     "expected",
+				},
+			}
+
+			target := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "mock",
+					Path:     "",
+					Property: expected,
+				},
+			}
+
+			flows := specs.FlowListInterface{
+				&specs.Flow{
+					Nodes: specs.NodeList{
+						{
+							Intermediate: &specs.ParameterMap{
+								Property: target,
+							},
+						},
+					},
+				},
+			}
+
+			return flows, target, expected, functions.Collection{}
+		},
+		"intermediate function": func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection) {
+			expected := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "expected",
+					Path:     "expected",
+				},
+			}
+
+			target := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "mock",
+					Path:     "",
+					Property: expected,
+				},
+			}
+
+			param := &specs.ParameterMap{}
+			mem := functions.Collection{}
+			stack := mem.Reserve(param)
+
+			stack["hash"] = &functions.Function{
+				Arguments: []*specs.Property{
+					target,
+				},
+			}
+
+			flows := specs.FlowListInterface{
+				&specs.Flow{
+					Nodes: specs.NodeList{
+						{
+							Intermediate: param,
+						},
+					},
+				},
+			}
+
+			return flows, target, expected, mem
+		},
+		"call function": func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection) {
+			expected := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "expected",
+					Path:     "expected",
+				},
+			}
+
+			target := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "mock",
+					Path:     "",
+					Property: expected,
+				},
+			}
+
+			param := &specs.ParameterMap{}
+			mem := functions.Collection{}
+			stack := mem.Reserve(param)
+
+			stack["hash"] = &functions.Function{
+				Arguments: []*specs.Property{
+					target,
+				},
+			}
+
+			flows := specs.FlowListInterface{
+				&specs.Flow{
+					Nodes: specs.NodeList{
+						{
+							Call: &specs.Call{
+								Request: param,
+							},
+						},
+					},
+				},
+			}
+
+			return flows, target, expected, mem
+		},
+		"condition": func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection) {
+			expected := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "expected",
+					Path:     "expected",
+				},
+			}
+
+			target := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "mock",
+					Path:     "",
+					Property: expected,
+				},
+			}
+
+			flows := specs.FlowListInterface{
+				&specs.Flow{
+					Nodes: specs.NodeList{
+						{
+							Condition: &specs.Condition{
+								Params: &specs.ParameterMap{
+									Params: map[string]*specs.Property{
+										"mock": target,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return flows, target, expected, functions.Collection{}
+		},
+		"flow on_error property": func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection) {
+			expected := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "expected",
+					Path:     "expected",
+				},
+			}
+
+			target := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "mock",
+					Path:     "",
+					Property: expected,
+				},
+			}
+
+			flows := specs.FlowListInterface{
+				&specs.Flow{
+					OnError: &specs.OnError{
+						Response: &specs.ParameterMap{
+							Property: target,
+						},
+					},
+				},
+			}
+
+			return flows, target, expected, functions.Collection{}
+		},
+		"flow on_error header": func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection) {
+			expected := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "expected",
+					Path:     "expected",
+				},
+			}
+
+			target := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "mock",
+					Path:     "",
+					Property: expected,
+				},
+			}
+
+			flows := specs.FlowListInterface{
+				&specs.Flow{
+					OnError: &specs.OnError{
+						Response: &specs.ParameterMap{
+							Header: specs.Header{
+								"mock": target,
+							},
+						},
+					},
+				},
+			}
+
+			return flows, target, expected, functions.Collection{}
+		},
+		"flow on_error param": func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection) {
+			expected := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "expected",
+					Path:     "expected",
+				},
+			}
+
+			target := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "mock",
+					Path:     "",
+					Property: expected,
+				},
+			}
+
+			flows := specs.FlowListInterface{
+				&specs.Flow{
+					OnError: &specs.OnError{
+						Response: &specs.ParameterMap{
+							Params: map[string]*specs.Property{
+								"mock": target,
+							},
+						},
+					},
+				},
+			}
+
+			return flows, target, expected, functions.Collection{}
+		},
+		"node on_error property": func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection) {
+			expected := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "expected",
+					Path:     "expected",
+				},
+			}
+
+			target := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "mock",
+					Path:     "",
+					Property: expected,
+				},
+			}
+
+			flows := specs.FlowListInterface{
+				&specs.Flow{
+					Nodes: specs.NodeList{
+						{
+							OnError: &specs.OnError{
+								Response: &specs.ParameterMap{
+									Property: target,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return flows, target, expected, functions.Collection{}
+		},
+		"node on_error header": func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection) {
+			expected := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "expected",
+					Path:     "expected",
+				},
+			}
+
+			target := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "mock",
+					Path:     "",
+					Property: expected,
+				},
+			}
+
+			flows := specs.FlowListInterface{
+				&specs.Flow{
+					Nodes: specs.NodeList{
+						{
+							OnError: &specs.OnError{
+								Response: &specs.ParameterMap{
+									Header: specs.Header{
+										"mock": target,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return flows, target, expected, functions.Collection{}
+		},
+		"node on_error param": func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection) {
+			expected := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "expected",
+					Path:     "expected",
+				},
+			}
+
+			target := &specs.Property{
+				Reference: &specs.PropertyReference{
+					Resource: "mock",
+					Path:     "",
+					Property: expected,
+				},
+			}
+
+			flows := specs.FlowListInterface{
+				&specs.Flow{
+					Nodes: specs.NodeList{
+						{
+							OnError: &specs.OnError{
+								Response: &specs.ParameterMap{
+									Params: map[string]*specs.Property{
+										"mock": target,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return flows, target, expected, functions.Collection{}
+		},
+		"proxy": func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection) {
 			expected := &specs.Property{
 				Reference: &specs.PropertyReference{
 					Resource: "expected",
@@ -72,9 +403,9 @@ func TestResolveReferences(t *testing.T) {
 				},
 			}
 
-			return flows, target, expected
+			return flows, target, expected, functions.Collection{}
 		},
-		"params": func() (specs.FlowListInterface, *specs.Property, *specs.Property) {
+		"params": func() (specs.FlowListInterface, *specs.Property, *specs.Property, functions.Collection) {
 			expected := &specs.Property{
 				Reference: &specs.PropertyReference{
 					Resource: "expected",
@@ -106,15 +437,15 @@ func TestResolveReferences(t *testing.T) {
 				},
 			}
 
-			return flows, target, expected
+			return flows, target, expected, functions.Collection{}
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctx := logger.WithLogger(broker.NewBackground())
-			flows, target, expected := test()
-			ResolveReferences(ctx, flows)
+			flows, target, expected, mem := test()
+			ResolveReferences(ctx, flows, mem)
 
 			if target.Reference.String() != expected.Reference.String() {
 				t.Errorf("unexpected reference '%s', expected '%s'", target.Reference, expected.Reference)
@@ -298,7 +629,8 @@ func TestResolveNodeReferences(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			node, target, expected := test()
-			ResolveNodeReferences(node)
+			mem := functions.Collection{}
+			ResolveNodeReferences(node, mem)
 
 			if target.Reference == nil {
 				t.Fatal("target reference not set")
@@ -403,7 +735,8 @@ func TestResolveOutputReferences(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			flow, target, expected := test()
 			ctx := logger.WithLogger(broker.NewBackground())
-			ResolveReferences(ctx, specs.FlowListInterface{flow})
+			mem := functions.Collection{}
+			ResolveReferences(ctx, specs.FlowListInterface{flow}, mem)
 
 			if target.Reference == nil {
 				t.Fatal("target reference not set")

--- a/pkg/specs/flows.go
+++ b/pkg/specs/flows.go
@@ -217,6 +217,21 @@ var (
 // Dependencies represents a collection of node dependencies
 type Dependencies map[string]*Node
 
+// Append appends the given input to the already existing dependencies and returns the result
+func (dependencies Dependencies) Append(input Dependencies) Dependencies {
+	result := make(Dependencies, len(dependencies)+len(input))
+
+	for key, val := range dependencies {
+		result[key] = val
+	}
+
+	for key, val := range input {
+		result[key] = val
+	}
+
+	return result
+}
+
 // Node represents a point inside a given flow where a request or rollback could be preformed.
 // Nodes could be executed synchronously or asynchronously.
 // All calls are referencing a service method, the service should match the alias defined inside the service.

--- a/pkg/specs/property.go
+++ b/pkg/specs/property.go
@@ -129,12 +129,13 @@ type EnumValue struct {
 // ParameterMap is the initial map of parameter names (keys) and their (templated) values (values)
 type ParameterMap struct {
 	*metadata.Meta
-	Schema   string               `json:"schema,omitempty"`
-	Params   map[string]*Property `json:"params,omitempty"`
-	Options  Options              `json:"options,omitempty"`
-	Header   Header               `json:"header,omitempty"`
-	Property *Property            `json:"property,omitempty"`
-	Stack    map[string]*Property `json:"stack,omitempty"`
+	DependsOn Dependencies         `json:"depends_on,omitempty"`
+	Schema    string               `json:"schema,omitempty"`
+	Params    map[string]*Property `json:"params,omitempty"`
+	Options   Options              `json:"options,omitempty"`
+	Header    Header               `json:"header,omitempty"`
+	Property  *Property            `json:"property,omitempty"`
+	Stack     map[string]*Property `json:"stack,omitempty"`
 }
 
 // Clone clones the given parameter map


### PR DESCRIPTION
This PR includes the dependencies made inside a parameter map through references.
These dependencies could be used to visualize the origins of dependencies.