### PR TITLE
Remove HCL reference from specs

### DIFF
--- a/examples/http/flow.hcl
+++ b/examples/http/flow.hcl
@@ -26,6 +26,6 @@ flow "FetchLatestProject" {
 
 		id = "{{ query:id }}"
 		title = "{{ query:title }}"
-		completed = "{{ query:title }}"
+		completed = "{{ query:completed }}"
 	}
 }

--- a/examples/http/flow.hcl
+++ b/examples/http/flow.hcl
@@ -26,6 +26,6 @@ flow "FetchLatestProject" {
 
 		id = "{{ query:id }}"
 		title = "{{ query:title }}"
-		completed = "{{ query:completed }}"
+		completed = "{{ query:title }}"
 	}
 }

--- a/pkg/broker/trace/trace.go
+++ b/pkg/broker/trace/trace.go
@@ -3,13 +3,16 @@ package trace
 import (
 	"errors"
 	"fmt"
-
-	"github.com/hashicorp/hcl/v2"
 )
+
+// Expression provides information about expression.
+type Expression interface {
+	Position() string
+}
 
 // Options able to be passed when constructing a tracing error
 type Options struct {
-	expr    hcl.Expression
+	expr    Expression
 	message string
 }
 
@@ -27,14 +30,11 @@ func New(opts ...Option) error {
 		return errors.New(options.message)
 	}
 
-	r := options.expr.Range()
-	position := fmt.Sprintf("%s:%d", r.Filename, r.Start.Line)
-
-	return fmt.Errorf("%s %s", position, options.message)
+	return fmt.Errorf("%s %s", options.expr.Position(), options.message)
 }
 
 // WithExpression sets the given expression as a trace option
-func WithExpression(expr hcl.Expression) Option {
+func WithExpression(expr Expression) Option {
 	return func(options *Options) {
 		options.expr = expr
 	}

--- a/pkg/broker/trace/trace_test.go
+++ b/pkg/broker/trace/trace_test.go
@@ -1,18 +1,19 @@
 package trace
 
-import (
-	"testing"
+import "testing"
 
-	"github.com/hashicorp/hcl/v2"
-	"github.com/zclconf/go-cty/cty"
-)
+type expressionFunc func() string
+
+func (fn expressionFunc) Position() string { return fn() }
 
 func TestNew(t *testing.T) {
+	expr := expressionFunc(func() string { return "file:10" })
+
 	tests := map[string][]Option{
 		"unexpected error":            {WithMessage("unexpected error")},
 		"unexpected error: component": {WithMessage("unexpected error: %s", "component")},
-		"file:10 unexpected error":    {WithMessage("unexpected error"), WithExpression(hcl.StaticExpr(cty.StringVal("prop"), hcl.Range{Filename: "file", Start: hcl.Pos{Line: 10}}))},
-		"file:10 ":                    {WithExpression(hcl.StaticExpr(cty.StringVal("prop"), hcl.Range{Filename: "file", Start: hcl.Pos{Line: 10}}))},
+		"file:10 unexpected error":    {WithMessage("unexpected error"), WithExpression(expr)},
+		"file:10 ":                    {WithExpression(expr)},
 	}
 
 	for expected, options := range tests {

--- a/pkg/providers/hcl/expression.go
+++ b/pkg/providers/hcl/expression.go
@@ -1,0 +1,15 @@
+package hcl
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+)
+
+// Expression is a wrapper over hcl.Expression providing extra functionality.
+type Expression struct{ hcl.Expression }
+
+// Position returns the position for tracer.
+func (expr Expression) Position() string {
+	return fmt.Sprintf("%s:%d", expr.Range().Filename, expr.Range().Start.Line)
+}

--- a/pkg/providers/hcl/expression_test.go
+++ b/pkg/providers/hcl/expression_test.go
@@ -1,0 +1,32 @@
+package hcl
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestExpressionPosition(t *testing.T) {
+	t.Run("get position", func(t *testing.T) {
+		var (
+			expected = "file:10"
+
+			expression = Expression{
+				hcl.StaticExpr(
+					cty.StringVal("prop"),
+					hcl.Range{
+						Filename: "file",
+						Start: hcl.Pos{
+							Line: 10,
+						},
+					},
+				),
+			}
+		)
+
+		if actual := expression.Position(); actual != expected {
+			t.Errorf("unexpected position %q should be %q", actual, expected)
+		}
+	})
+}

--- a/pkg/providers/hcl/specs.go
+++ b/pkg/providers/hcl/specs.go
@@ -674,7 +674,7 @@ func ParseIntermediateProperty(ctx *broker.Context, path string, property *hcl.A
 	result := &specs.Property{
 		Name:  property.Name,
 		Path:  template.JoinPath(path, property.Name),
-		Expr:  property.Expr,
+		Expr:  &Expression{property.Expr},
 		Label: labels.Optional,
 	}
 

--- a/pkg/specs/property.go
+++ b/pkg/specs/property.go
@@ -1,7 +1,6 @@
 package specs
 
 import (
-	"github.com/hashicorp/hcl/v2"
 	"github.com/jexia/semaphore/pkg/specs/labels"
 	"github.com/jexia/semaphore/pkg/specs/metadata"
 	"github.com/jexia/semaphore/pkg/specs/types"
@@ -60,6 +59,11 @@ func (objects Schemas) Append(arg Schemas) {
 	}
 }
 
+// Expression provides information about expression.
+type Expression interface {
+	Position() string
+}
+
 // Property represents a value property.
 // A value property could contain a constant value or a value reference.
 type Property struct {
@@ -73,7 +77,7 @@ type Property struct {
 	Label     labels.Label         `json:"label,omitempty"`
 	Reference *PropertyReference   `json:"reference,omitempty"`
 	Nested    map[string]*Property `json:"nested,omitempty"`
-	Expr      hcl.Expression       `json:"-"` // TODO: replace this with a custom solution
+	Expr      Expression           `json:"-"`
 	Raw       string               `json:"raw,omitempty"`
 	Options   Options              `json:"options,omitempty"`
 	Enum      *Enum                `json:"enum,omitempty"`


### PR DESCRIPTION
introduce local `Expression` interface + wrapper over `hcl.Expression` to fit local interface