### PR TITLE
Introducing template strings and strconcat function

### DIFF
--- a/cmd/semaphore/daemon/config/options.go
+++ b/cmd/semaphore/daemon/config/options.go
@@ -3,6 +3,7 @@ package config
 import (
 	"github.com/jexia/semaphore"
 	"github.com/jexia/semaphore/cmd/semaphore/daemon/providers"
+	"github.com/jexia/semaphore/cmd/semaphore/functions"
 	"github.com/jexia/semaphore/cmd/semaphore/middleware"
 	"github.com/jexia/semaphore/pkg/broker"
 	"github.com/jexia/semaphore/pkg/broker/logger"
@@ -119,6 +120,7 @@ func NewCore(ctx *broker.Context, flags *Daemon) (semaphore.Options, error) {
 		semaphore.WithCaller(micro.NewCaller("micro-grpc", microGRPC.NewService())),
 		semaphore.WithCaller(grpc.NewCaller()),
 		semaphore.WithCaller(http.NewCaller()),
+		semaphore.WithFunctions(functions.Default),
 	}
 
 	for _, path := range flags.Files {

--- a/cmd/semaphore/functions/errors.go
+++ b/cmd/semaphore/functions/errors.go
@@ -1,0 +1,43 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/jexia/semaphore/pkg/prettyerr"
+	"github.com/jexia/semaphore/pkg/specs"
+	"github.com/jexia/semaphore/pkg/specs/types"
+)
+
+type wrapErr struct {
+	Inner error
+}
+
+func (i wrapErr) Unwrap() error {
+	return i.Inner
+}
+
+// ErrInvalidArgument is thrown when a given argument is invalid
+type ErrInvalidArgument struct {
+	wrapErr
+	Function string
+	Property *specs.Property
+	Expected types.Type
+}
+
+// Error returns a description of the given error as a string
+func (e ErrInvalidArgument) Error() string {
+	return fmt.Sprintf("invalid argument %s in %s expected %s", e.Property.Type, e.Function, e.Expected)
+}
+
+// Prettify returns the prettified version of the given error
+func (e ErrInvalidArgument) Prettify() prettyerr.Error {
+	return prettyerr.Error{
+		Code:    "InvalidArgument",
+		Message: e.Error(),
+		Details: map[string]interface{}{
+			"Function": e.Function,
+			"Type":     e.Property.Type,
+			"Expected": e.Expected,
+		},
+	}
+}

--- a/cmd/semaphore/functions/functions.go
+++ b/cmd/semaphore/functions/functions.go
@@ -1,0 +1,8 @@
+package functions
+
+import "github.com/jexia/semaphore/pkg/functions"
+
+// Default represents the default functions collection
+var Default = functions.Custom{
+	"strconcat": Strconcat,
+}

--- a/cmd/semaphore/functions/strconcat.go
+++ b/cmd/semaphore/functions/strconcat.go
@@ -1,0 +1,55 @@
+package functions
+
+import (
+	"github.com/jexia/semaphore/pkg/functions"
+	"github.com/jexia/semaphore/pkg/references"
+	"github.com/jexia/semaphore/pkg/specs"
+	"github.com/jexia/semaphore/pkg/specs/labels"
+	"github.com/jexia/semaphore/pkg/specs/types"
+)
+
+// Strconcat compiles the given arguments and constructs a new executable
+// function for the given arguments.
+func Strconcat(args ...*specs.Property) (*specs.Property, functions.Exec, error) {
+	result := &specs.Property{
+		Name:  "concat",
+		Type:  types.String,
+		Label: labels.Optional,
+	}
+
+	for _, arg := range args {
+		if arg.Type != types.String {
+			return nil, nil, ErrInvalidArgument{
+				Property: arg,
+				Expected: types.String,
+				Function: "strconcat",
+			}
+		}
+	}
+
+	handle := func(store references.Store) error {
+		var result string
+
+		for _, arg := range args {
+			var value string
+
+			if arg.Default != nil {
+				value = arg.Default.(string)
+			}
+
+			if arg.Reference != nil {
+				ref := store.Load(arg.Reference.Resource, arg.Reference.Path)
+				if ref != nil {
+					value = ref.Value.(string)
+				}
+			}
+
+			result += value
+		}
+
+		store.StoreValue("", ".", result)
+		return nil
+	}
+
+	return result, handle, nil
+}

--- a/cmd/semaphore/functions/strconcat.go
+++ b/cmd/semaphore/functions/strconcat.go
@@ -1,6 +1,8 @@
 package functions
 
 import (
+	"strings"
+
 	"github.com/jexia/semaphore/pkg/functions"
 	"github.com/jexia/semaphore/pkg/references"
 	"github.com/jexia/semaphore/pkg/specs"
@@ -28,7 +30,7 @@ func Strconcat(args ...*specs.Property) (*specs.Property, functions.Exec, error)
 	}
 
 	handle := func(store references.Store) error {
-		var result string
+		result := strings.Builder{}
 
 		for _, arg := range args {
 			var value string
@@ -44,10 +46,13 @@ func Strconcat(args ...*specs.Property) (*specs.Property, functions.Exec, error)
 				}
 			}
 
-			result += value
+			_, err := result.WriteString(value)
+			if err != nil {
+				return err
+			}
 		}
 
-		store.StoreValue("", ".", result)
+		store.StoreValue("", ".", result.String())
 		return nil
 	}
 

--- a/pkg/lookup/lookup.go
+++ b/pkg/lookup/lookup.go
@@ -77,12 +77,11 @@ func GetAvailableResources(flow specs.FlowInterface, breakpoint string) map[stri
 	}
 
 	if breakpoint == template.OutputResource {
-		references[template.ErrorResource] = ReferenceMap{
-			template.ResponseResource: OnErrLookup(template.OutputResource, flow.GetOnError()),
-		}
-
 		if flow.GetOnError() != nil {
-			references[template.ErrorResource][template.ParamsResource] = ParamsLookup(flow.GetOnError().Params, flow, "")
+			references[template.ErrorResource] = ReferenceMap{
+				template.ResponseResource: OnErrLookup(template.OutputResource, flow.GetOnError()),
+				template.ParamsResource:   ParamsLookup(flow.GetOnError().Params, flow, ""),
+			}
 		}
 	}
 
@@ -134,6 +133,14 @@ func GetAvailableResources(flow specs.FlowInterface, breakpoint string) map[stri
 				if node.GetOnError().Response != nil {
 					references[node.ID][template.ErrorResource] = PropertyLookup(node.GetOnError().Response.Property)
 				}
+			}
+		}
+	}
+
+	if flow.GetOutput() != nil {
+		if flow.GetOutput().Stack != nil {
+			for key, returns := range flow.GetOutput().Stack {
+				references[template.StackResource][key] = PropertyLookup(returns)
 			}
 		}
 	}

--- a/pkg/lookup/lookup_test.go
+++ b/pkg/lookup/lookup_test.go
@@ -474,6 +474,32 @@ func NewMockFlow(name string) *specs.Flow {
 		Input: &specs.ParameterMap{
 			Property: NewInputMockProperty(),
 		},
+		OnError: &specs.OnError{
+			Response: &specs.ParameterMap{
+				Property: NewResultMockProperty(),
+				Params: map[string]*specs.Property{
+					"message": {
+						Path:    "message",
+						Default: "hello world",
+						Type:    types.String,
+						Label:   labels.Optional,
+					},
+					"name": {
+						Path:    "message",
+						Default: "hello world",
+						Type:    types.String,
+						Label:   labels.Optional,
+					},
+					"reference": {
+						Path: "reference",
+						Reference: &specs.PropertyReference{
+							Resource: name,
+							Path:     "message",
+						},
+					},
+				},
+			},
+		},
 		Nodes: specs.NodeList{
 			NewMockCall("first"),
 			NewMockCall("second"),
@@ -504,6 +530,23 @@ func TestGetAvailableResources(t *testing.T) {
 		"output": func() ([]string, map[string]ReferenceMap) {
 			flow := NewMockFlow("first")
 			expected := []string{template.StackResource, template.ErrorResource, "input", "first", "second", "third"}
+
+			result := GetAvailableResources(flow, "output")
+			return expected, result
+		},
+		"output only": func() ([]string, map[string]ReferenceMap) {
+			flow := NewMockFlow("first")
+
+			flow.OnError = nil
+			flow.Input = nil
+			flow.Nodes = nil
+			flow.Output = &specs.ParameterMap{
+				Stack: map[string]*specs.Property{
+					"hash": NewResultMockProperty(),
+				},
+			}
+
+			expected := []string{template.StackResource}
 
 			result := GetAvailableResources(flow, "output")
 			return expected, result

--- a/pkg/specs/template/template.go
+++ b/pkg/specs/template/template.go
@@ -8,12 +8,16 @@ import (
 	"github.com/jexia/semaphore/pkg/broker/logger"
 	"github.com/jexia/semaphore/pkg/broker/trace"
 	"github.com/jexia/semaphore/pkg/specs"
+	"github.com/jexia/semaphore/pkg/specs/labels"
+	"github.com/jexia/semaphore/pkg/specs/types"
 	"go.uber.org/zap"
 )
 
 var (
 	// ReferencePattern is the matching pattern for references
 	ReferencePattern = regexp.MustCompile(`^[a-zA-Z0-9_\-\.]*:[a-zA-Z0-9\^\&\%\$@_\-\.]*$`)
+	// StringPattern is the matching pattern for strings
+	StringPattern = regexp.MustCompile(`^\'(.+)\'$`)
 )
 
 const (
@@ -115,6 +119,18 @@ func ParseReference(path string, name string, value string) (*specs.Property, er
 func ParseContent(path string, name string, content string) (*specs.Property, error) {
 	if ReferencePattern.MatchString(content) {
 		return ParseReference(path, name, content)
+	}
+
+	if StringPattern.MatchString(content) {
+		matched := StringPattern.FindStringSubmatch(content)
+
+		return &specs.Property{
+			Name:    name,
+			Path:    path,
+			Type:    types.String,
+			Label:   labels.Optional,
+			Default: matched[1],
+		}, nil
 	}
 
 	return &specs.Property{


### PR DESCRIPTION
This PR introduces the ability to define static strings inside a template (`{{ }}`). This feature allows for the passing of static values in functions.

```
{{ strconcat('Bearer ', input:token ) }}
```