### PR TITLE
Fix calling services by HTTP with query params in endpoint url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /.idea
 
 bin/
+tmp/

--- a/pkg/flow/caller.go
+++ b/pkg/flow/caller.go
@@ -3,6 +3,7 @@ package flow
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/jexia/semaphore/pkg/broker"
@@ -150,7 +151,7 @@ func (caller *caller) Do(ctx context.Context, store references.Store) error {
 		if caller.response.Codec != nil {
 			err := caller.response.Codec.Unmarshal(reader, store)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to unmarshal response into the store: %w", err)
 			}
 		}
 

--- a/pkg/transport/http/caller_test.go
+++ b/pkg/transport/http/caller_test.go
@@ -61,12 +61,17 @@ func TestCaller(t *testing.T) {
 
 	refs := references.NewReferenceStore(1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "/Path?query=value"
+		got := r.URL.String()
+		if got != want {
+			t.Errorf("expected server addressed by %s, but got %s", want, got)
+		}
 		w.Write([]byte(`{"message":"` + message + `"}`))
 	}))
 
 	defer server.Close()
 
-	service := NewMockService(server.URL, "GET", "/")
+	service := NewMockService(server.URL, "GET", "/Path?query=value")
 	caller, err := NewMockCaller().Dial(service, nil, nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Given

Given a service definition with a method:

```
rpc Get(Query) returns (Item) {
    option (semaphore.api.http) = {
        endpoint: "/v2/?query=value"
        method: "GET"
    };
};
```

## Result

The HTTP caller escapes the `?` symbol with `%3F`, the query does not work (leads to a wrong URL).

## Expected behavior

The `?` symbold should not be escaped, the built URL has to look like http://example.com/v2?query=value