### PR TITLE
GraphQL improvements and nested arguments fix

### DIFF
--- a/examples/graphql/flow.hcl
+++ b/examples/graphql/flow.hcl
@@ -1,5 +1,5 @@
 endpoint "latest_todo" "graphql" {
-	path = "latest.todo"
+	path = "todo.latest"
 	name = "LatestTodo"
 	base = "query"
 }
@@ -20,8 +20,8 @@ flow "latest_todo" {
 }
 
 endpoint "todo" "graphql" {
-	path = "todo"
-	name = "Todo"
+	path = "todo.query"
+	name = "TodoQuery"
 	base = "query"
 }
 

--- a/pkg/codec/json/array.go
+++ b/pkg/codec/json/array.go
@@ -1,8 +1,6 @@
 package json
 
 import (
-	"log"
-
 	"github.com/francoispqt/gojay"
 	"github.com/jexia/semaphore/pkg/references"
 	"github.com/jexia/semaphore/pkg/specs"
@@ -58,7 +56,6 @@ func (array *Array) MarshalJSONArray(enc *gojay.Encoder) {
 	}
 
 	for _, store := range array.ref.Repeated {
-		log.Println(store, array.template.Type())
 		switch {
 		case array.template.Message != nil:
 			object := NewObject(array.resource, array.template.Message, store)

--- a/pkg/transport/graphql/field.go
+++ b/pkg/transport/graphql/field.go
@@ -77,12 +77,10 @@ func SetFieldPath(object *graphql.Object, path string, field *graphql.Field) err
 	target, has := fields[key]
 
 	if len(parts) > 1 {
-		config := graphql.ObjectConfig{
+		nested := graphql.NewObject(graphql.ObjectConfig{
 			Name:   key,
 			Fields: make(graphql.Fields),
-		}
-
-		nested := graphql.NewObject(config)
+		})
 
 		if has {
 			result, isObject := target.Type.(*graphql.Object)
@@ -95,17 +93,6 @@ func SetFieldPath(object *graphql.Object, path string, field *graphql.Field) err
 
 			nested = result
 		}
-
-		part := &graphql.Field{
-			Name: key,
-			Type: nested,
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-				return p.Source, nil
-			},
-		}
-
-		object.AddFieldConfig(key, part)
-		object.Fields()
 
 		return SetFieldPath(nested, NewPath(parts[1:]), field)
 	}


### PR DESCRIPTION
This PR fixes the ability to construct nested arguments. This PR prepares for the ability to inherit sources and create advanced GraphQL schemas.

```hcl
endpoint "latest_todo" "graphql" {
	path = "todo.latest"
	name = "LatestTodo"
	base = "query"
}

endpoint "todo" "graphql" {
	path = "todo.query"
	name = "TodoQuery"
	base = "query"
}
```