### PR TITLE
fix: Service Discovery documentation

### DIFF
--- a/website/docs/service_discovery-configuration.md
+++ b/website/docs/service_discovery-configuration.md
@@ -1,8 +1,8 @@
 ---
 id: service_discovery.configuration
 title: Service Discovery Client Configuration
-sidebar_label: Configuration
-slug: /service_discovert/configuration
+sidebar_label: Service Discovery
+slug: /service_discovery/configuration
 ---
 
 ## Intro

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -29,10 +29,10 @@ module.exports = {
       id: 'functions',
     },
     {
-      type: 'doc',
-      id: 'devops',
+      type: 'category',
       label: 'Infrastructure',
       items: [
+        "devops",
         "service_discovery.configuration",
       ]
     }


### PR DESCRIPTION
The service discovery sidebar entry was broken (it mixed both the `doc` and `category` types)
I also fixed the label and slug for the service discovery page