### PR TITLE
Fix OpenAPI3 generation for a flow without inputs

### DIFF
--- a/pkg/generators/openapi3/generator.go
+++ b/pkg/generators/openapi3/generator.go
@@ -147,7 +147,7 @@ func GenerateOperation(object *Object, options *transport.EndpointOptions, flow 
 	}
 
 	if output != nil {
-		if input.Property != nil {
+		if output.Property != nil {
 			result.Responses = map[string]*Response{
 				"default": {
 					Content: map[string]MediaType{
@@ -159,9 +159,9 @@ func GenerateOperation(object *Object, options *transport.EndpointOptions, flow 
 					},
 				},
 			}
-		}
 
-		IncludeParameterMap(object, output)
+			IncludeParameterMap(object, output)
+		}
 	}
 
 	return result

--- a/pkg/generators/openapi3/generator.go
+++ b/pkg/generators/openapi3/generator.go
@@ -14,14 +14,14 @@ import (
 	transport "github.com/jexia/semaphore/pkg/transport/http"
 )
 
-// Generate generates a openapi v3.0 specification object
+// Generate generates a openapi v3.0 specification object.
 func Generate(endpoints specs.EndpointList, flows specs.FlowListInterface, option Options) (*Object, error) {
 	result := Object{
 		Version: "3.0.0",
 	}
 
 	for _, endpoint := range endpoints {
-		// OpenAPI specs are ment for HTTP endpoints
+		// OpenAPI specs are meant for HTTP endpoints
 		if endpoint.Listener != "http" {
 			continue
 		}
@@ -40,7 +40,7 @@ func Generate(endpoints specs.EndpointList, flows specs.FlowListInterface, optio
 	return &result, nil
 }
 
-// IncludeEndpoint includes the given endpoint into the object paths
+// IncludeEndpoint includes the given endpoint into the object paths.
 func IncludeEndpoint(object *Object, endpoint *specs.Endpoint, flow specs.FlowInterface, option Options) error {
 	options, err := transport.ParseEndpointOptions(endpoint.Options)
 	if err != nil {
@@ -64,7 +64,7 @@ func IncludeEndpoint(object *Object, endpoint *specs.Endpoint, flow specs.FlowIn
 		object.Paths[path] = &PathItem{}
 	}
 
-	operation := GenerateOperation(object, endpoint, options, flow, option)
+	operation := GenerateOperation(object, options, flow, option)
 	result := object.Paths[path]
 
 	switch options.Method {
@@ -89,8 +89,8 @@ func IncludeEndpoint(object *Object, endpoint *specs.Endpoint, flow specs.FlowIn
 	return nil
 }
 
-// GenerateOperation generates a operation object from the given endpoint and options
-func GenerateOperation(object *Object, endpoint *specs.Endpoint, options *transport.EndpointOptions, flow specs.FlowInterface, option Options) *Operation {
+// GenerateOperation generates a operation object from the OpenAPI3 object.
+func GenerateOperation(object *Object, options *transport.EndpointOptions, flow specs.FlowInterface, option Options) *Operation {
 	input := flow.GetInput()
 	output := flow.GetOutput()
 	result := &Operation{}
@@ -167,7 +167,7 @@ func GenerateOperation(object *Object, endpoint *specs.Endpoint, options *transp
 	return result
 }
 
-// GenerateParameter includes the given parameter to the available parameters
+// GenerateParameter includes the given parameter to the available parameters.
 func GenerateParameter(key string, required bool, in ParameterIn, property *specs.Property) *Parameter {
 	result := &Parameter{
 		Name:     key,
@@ -188,7 +188,7 @@ func GenerateParameter(key string, required bool, in ParameterIn, property *spec
 	return result
 }
 
-// IncludeParameterMap includes the given parameters into the object schema components
+// IncludeParameterMap includes the given parameters into the object schema components.
 func IncludeParameterMap(object *Object, params *specs.ParameterMap) {
 	if params == nil {
 		return
@@ -205,7 +205,7 @@ func IncludeParameterMap(object *Object, params *specs.ParameterMap) {
 	object.Components.Schemas[params.Schema] = GenerateSchema(params.Property.Description, params.Property.Template)
 }
 
-// GenerateSchema generates a new schema for the given property
+// GenerateSchema generates a new schema for the given property.
 func GenerateSchema(description string, property specs.Template) *Schema {
 	result := &Schema{
 		Description: description,
@@ -215,8 +215,6 @@ func GenerateSchema(description string, property specs.Template) *Schema {
 	switch {
 	case property.Scalar != nil:
 		result.Default = property.Scalar.Default
-
-		break
 	case property.Message != nil && len(property.Message) > 0:
 		result.Properties = make(map[string]*Schema, len(property.Message))
 
@@ -227,8 +225,6 @@ func GenerateSchema(description string, property specs.Template) *Schema {
 				result.Required = append(result.Required, nested.Name)
 			}
 		}
-
-		break
 	case property.Enum != nil:
 		// ensure property enum order
 		result.Enum = make([]interface{}, len(property.Enum.Keys))
@@ -243,8 +239,6 @@ func GenerateSchema(description string, property specs.Template) *Schema {
 		for pos, key := range keys {
 			result.Enum[pos] = property.Enum.Positions[int32(key)].Key
 		}
-
-		break
 	case property.Repeated != nil:
 		template, err := property.Repeated.Template()
 		if err != nil {

--- a/pkg/generators/openapi3/openapi_test.go
+++ b/pkg/generators/openapi3/openapi_test.go
@@ -29,14 +29,17 @@ func TestOpenAPI3GenerationWithoutReference(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := logger.WithLogger(broker.NewBackground())
-	files, err := provider.ResolvePath(ctx, []string{}, path)
+	files, err := provider.ResolvePath(logger.WithLogger(broker.NewBackground()), []string{}, path)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, file := range files {
+		file := file
+
 		t.Run(file.Name(), func(t *testing.T) {
+			t.Parallel()
+
 			ctx := logger.WithLogger(broker.NewBackground())
 
 			options, err := hcl.GetOptions(ctx, file.Path)
@@ -49,7 +52,6 @@ func TestOpenAPI3GenerationWithoutReference(t *testing.T) {
 				semaphore.WithCodec(json.NewConstructor()),
 				semaphore.WithCaller(http.NewCaller()),
 			)
-
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -114,14 +116,17 @@ func TestOpenAPI3GenerationWithReference(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := logger.WithLogger(broker.NewBackground())
-	files, err := provider.ResolvePath(ctx, []string{}, path)
+	files, err := provider.ResolvePath(logger.WithLogger(broker.NewBackground()), []string{}, path)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, file := range files {
+		file := file
+
 		t.Run(file.Name(), func(t *testing.T) {
+			t.Parallel()
+
 			ctx := logger.WithLogger(broker.NewBackground())
 
 			options, err := hcl.GetOptions(ctx, file.Path)
@@ -134,7 +139,6 @@ func TestOpenAPI3GenerationWithReference(t *testing.T) {
 				semaphore.WithCodec(json.NewConstructor()),
 				semaphore.WithCaller(http.NewCaller()),
 			)
-
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/generators/openapi3/tests/flow-no-input.hcl
+++ b/pkg/generators/openapi3/tests/flow-no-input.hcl
@@ -1,0 +1,10 @@
+protobuffers = ["./*.proto"]
+
+endpoint "CreateUser" "http" {
+  endpoint = "/user"
+  method = "post"
+}
+
+flow "CreateUser" {
+  output "com.semaphore.User" {}
+}

--- a/pkg/generators/openapi3/tests/flow-no-output.hcl
+++ b/pkg/generators/openapi3/tests/flow-no-output.hcl
@@ -1,0 +1,10 @@
+protobuffers = ["./*.proto"]
+
+endpoint "CreateUser" "http" {
+  endpoint = "/user"
+  method = "post"
+}
+
+flow "CreateUser" {
+  input "com.semaphore.User" {}
+}

--- a/pkg/generators/openapi3/tests/no_ref/flow-no-input.yaml
+++ b/pkg/generators/openapi3/tests/no_ref/flow-no-input.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: ""
+  version: ""
+paths:
+  /user:
+    post:
+      responses:
+        default:
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/com.semaphore.User"
+components:
+  schemas:
+    com.semaphore.User:
+      properties:
+        email:
+          type: string
+        id:
+          type: integer
+        name:
+          type: string
+        interests:
+          items:
+            type: string
+        status:
+          type: string
+          enum:
+            - UNAVAILABLE
+            - AVAILABLE
+        username:
+          type: string

--- a/pkg/generators/openapi3/tests/no_ref/flow-no-output.yaml
+++ b/pkg/generators/openapi3/tests/no_ref/flow-no-output.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: ""
+  version: ""
+paths:
+  /user:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/com.semaphore.User"
+        required: false
+components:
+  schemas:
+    com.semaphore.User:
+      properties:
+        email:
+          type: string
+        id:
+          type: integer
+        name:
+          type: string
+        interests:
+          items:
+            type: string
+        status:
+          type: string
+          enum:
+            - UNAVAILABLE
+            - AVAILABLE
+        username:
+          type: string

--- a/pkg/generators/openapi3/tests/ref/flow-no-input.yaml
+++ b/pkg/generators/openapi3/tests/ref/flow-no-input.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: ""
+  version: ""
+paths:
+  /user:
+    post:
+      responses:
+        default:
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/com.semaphore.User"
+components:
+  schemas:
+    com.semaphore.User:
+      properties:
+        email:
+          type: string
+        id:
+          type: integer
+        interests:
+          items:
+            type: string
+        name:
+          type: string
+        status:
+          type: string
+          enum:
+            - UNAVAILABLE
+            - AVAILABLE
+        username:
+          type: string

--- a/pkg/generators/openapi3/tests/ref/flow-no-output.yaml
+++ b/pkg/generators/openapi3/tests/ref/flow-no-output.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  title: ""
+  version: ""
+paths:
+  /user:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateUserInput"
+        required: false
+components:
+  schemas:
+    CreateUserInput: {}


### PR DESCRIPTION
While processing the flow outputs during the OpenAPI3 generation the flow inputs where checked by accident.
I added an additional check to test that flows without output also/still work.

Running `semaphore generate openapi3 -f pkg/generators/openapi3/tests/flow-no-input.hcl` now results in the following (instead of a panic):
```
# Code generated by Semaphore. DO NOT EDIT.
# Semaphore version: unknown
# Timestamp: Wed, 28 Apr 2021 16:17:45 GMT
openapi: 3.0.0
info:
  title: Public API
  version: ""
  description: generated by Semaphore
paths:
  /user:
    post:
      responses:
        default:
          description: ""
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/com.semaphore.User'
components:
  schemas:
    com.semaphore.User:
      properties:
        email:
          type: string
        id:
          type: integer
        interests:
          items:
            type: string
        name:
          type: string
        status:
          type: string
          enum:
          - UNAVAILABLE
          - AVAILABLE
        username:
          type: string
```

Next to that I fixed some (minor) issues found by the linter.

Fixes #177 