### PR TITLE
refactor: specs/template functions should return spec.Template type

### DIFF
--- a/pkg/specs/property.go
+++ b/pkg/specs/property.go
@@ -46,21 +46,9 @@ type Property struct {
 	Template `json:"template" yaml:"template"`
 }
 
-// DefaultValue returns rge default value for a given property.
+// DefaultValue returns the default value for a given property.
 func (property *Property) DefaultValue() interface{} {
-	t := property.Template
-	switch {
-	case t.Scalar != nil:
-		return t.Scalar.Default
-	case t.Message != nil:
-		return nil
-	case t.Repeated != nil:
-		return nil
-	case t.Enum != nil:
-		return nil
-	}
-
-	return nil
+	return property.Template.DefaultValue()
 }
 
 // Empty checks if the property has any defined type

--- a/pkg/specs/template.go
+++ b/pkg/specs/template.go
@@ -45,6 +45,22 @@ func (template Template) Type() types.Type {
 	return types.Unknown
 }
 
+// Return the default value for the template (type), assuming the current type has a default.
+func (template Template) DefaultValue() interface{} {
+	switch {
+	case template.Scalar != nil:
+		return template.Scalar.Default
+	case template.Message != nil:
+		return nil
+	case template.Repeated != nil:
+		return nil
+	case template.Enum != nil:
+		return nil
+	}
+
+	return nil
+}
+
 // Clone internal value.
 func (template Template) Clone() Template {
 	clone := Template{

--- a/pkg/specs/template/template_test.go
+++ b/pkg/specs/template/template_test.go
@@ -6,11 +6,10 @@ import (
 	"github.com/jexia/semaphore/v2/pkg/broker"
 	"github.com/jexia/semaphore/v2/pkg/broker/logger"
 	"github.com/jexia/semaphore/v2/pkg/specs"
-	"github.com/jexia/semaphore/v2/pkg/specs/labels"
 	"github.com/jexia/semaphore/v2/pkg/specs/types"
 )
 
-func CompareProperties(t *testing.T, actual, expected *specs.Property) {
+func CompareTemplates(t *testing.T, actual, expected specs.Template) {
 	if err := actual.Compare(expected); err != nil {
 		t.Errorf("unexpected property: %s", err)
 	}
@@ -56,190 +55,119 @@ func TestGetTemplateContent(t *testing.T) {
 }
 
 func TestParseTemplateContent(t *testing.T) {
-	var (
-		name  = ""
-		path  = "message"
-		tests = map[string]*specs.Property{
-			"'prefix'": {
-				Name:  name,
-				Path:  path,
-				Label: labels.Optional,
-				Template: specs.Template{
-					Scalar: &specs.Scalar{
-						Type:    types.String,
-						Default: "prefix",
-					},
-				},
+	tests := map[string]specs.Template{
+		"'prefix'": {
+			Scalar: &specs.Scalar{
+				Type:    types.String,
+				Default: "prefix",
 			},
-			"'edge''": {
-				Name:  name,
-				Path:  path,
-				Label: labels.Optional,
-				Template: specs.Template{
-					Scalar: &specs.Scalar{
-						Type:    types.String,
-						Default: "edge'",
-					},
-				},
+		},
+		"'edge''": {
+			Scalar: &specs.Scalar{
+				Type:    types.String,
+				Default: "edge'",
 			},
-			"input:message": {
-				Name: name,
-				Path: path,
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input",
-						Path:     "message",
-					},
-				},
+		},
+		"input:message": {
+			Reference: &specs.PropertyReference{
+				Resource: "input",
+				Path:     "message",
 			},
-			"input:user-id": {
-				Name: name,
-				Path: path,
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input",
-						Path:     "user-id",
-					},
-				},
+		},
+		"input:user-id": {
+			Reference: &specs.PropertyReference{
+				Resource: "input",
+				Path:     "user-id",
 			},
-			"input.header:Authorization": {
-				Name: name,
-				Path: path,
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input.header",
-						Path:     "authorization",
-					},
-				},
+		},
+		"input.header:Authorization": {
+			Reference: &specs.PropertyReference{
+				Resource: "input.header",
+				Path:     "authorization",
 			},
-			"input.header:User-Id": {
-				Name: name,
-				Path: path,
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input.header",
-						Path:     "user-id",
-					},
-				},
+		},
+		"input.header:User-Id": {
+			Reference: &specs.PropertyReference{
+				Resource: "input.header",
+				Path:     "user-id",
 			},
-			"input.header:": {
-				Path: path,
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input.header",
-					},
-				},
+		},
+		"input.header:": {
+			Reference: &specs.PropertyReference{
+				Resource: "input.header",
 			},
-		}
-	)
+		},
+	}
 
 	for input, expected := range tests {
 		t.Run(input, func(t *testing.T) {
-			property, err := ParseContent(path, name, input)
+			property, err := ParseContent(input)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if property.Path != expected.Path {
-				t.Errorf("unexpected path '%s', expected '%s'", property.Path, expected.Path)
-			}
-
-			CompareProperties(t, property, expected)
+			CompareTemplates(t, property, expected)
 		})
 	}
 }
 
 func TestParseReference(t *testing.T) {
-	var (
-		name  = ""
-		path  = "message"
-		tests = map[string]*specs.Property{
-			"input:message": {
-				Name: name,
-				Path: path,
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input",
-						Path:     "message",
-					},
-				},
+	tests := map[string]specs.Template{
+		"input:message": {
+			Reference: &specs.PropertyReference{
+				Resource: "input",
+				Path:     "message",
 			},
-			"input:user-id": {
-				Name: name,
-				Path: path,
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input",
-						Path:     "user-id",
-					},
-				},
+		},
+		"input:user-id": {
+			Reference: &specs.PropertyReference{
+				Resource: "input",
+				Path:     "user-id",
 			},
-			"input.header:Authorization": {
-				Name: name,
-				Path: path,
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input.header",
-						Path:     "authorization",
-					},
-				},
+		},
+		"input.header:Authorization": {
+			Reference: &specs.PropertyReference{
+				Resource: "input.header",
+				Path:     "authorization",
 			},
-			"input.header:User-Id": {
-				Name: name,
-				Path: path,
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input.header",
-						Path:     "user-id",
-					},
-				},
+		},
+		"input.header:User-Id": {
+			Reference: &specs.PropertyReference{
+				Resource: "input.header",
+				Path:     "user-id",
 			},
-			"input:": {
-				Path: path,
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input",
-					},
-				},
+		},
+		"input:": {
+			Reference: &specs.PropertyReference{
+				Resource: "input",
 			},
-			"input.header:": {
-				Path: path,
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input.header",
-					},
-				},
+		},
+		"input.header:": {
+			Reference: &specs.PropertyReference{
+				Resource: "input.header",
 			},
-			"input": {
-				Path: path,
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input",
-					},
-				},
+		},
+		"input": {
+			Reference: &specs.PropertyReference{
+				Resource: "input",
 			},
-		}
-	)
+		},
+	}
 
 	for input, expected := range tests {
 		t.Run(input, func(t *testing.T) {
-			property, err := ParseReference(path, name, input)
+			property, err := ParseReference(input)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if property.Path != expected.Path {
-				t.Errorf("unexpected path '%s', expected '%s'", property.Path, expected.Path)
-			}
-
-			CompareProperties(t, property, expected)
+			CompareTemplates(t, property, expected)
 		})
 	}
 }
 
 func TestParseReferenceErr(t *testing.T) {
 	var (
-		name  = ""
 		path  = "message"
 		tests = []string{
 			"input:..",
@@ -249,7 +177,7 @@ func TestParseReferenceErr(t *testing.T) {
 	for _, input := range tests {
 		t.Run(input, func(t *testing.T) {
 			ctx := logger.WithLogger(broker.NewBackground())
-			_, err := Parse(ctx, path, name, input)
+			_, err := Parse(ctx, path, input)
 			if err == nil {
 				t.Fatal("unexpected pass")
 			}
@@ -258,18 +186,14 @@ func TestParseReferenceErr(t *testing.T) {
 }
 
 func TestUnknownReferencePattern(t *testing.T) {
-	var (
-		name  = ""
-		path  = "message"
-		tests = []string{
-			"input",
-			"value",
-		}
-	)
+	tests := []string{
+		"input",
+		"value",
+	}
 
 	for _, input := range tests {
 		t.Run(input, func(t *testing.T) {
-			_, err := ParseContent(path, name, input)
+			_, err := ParseContent(input)
 			if err != nil {
 				t.Fatalf("unexpected err %s", err)
 			}
@@ -278,75 +202,54 @@ func TestUnknownReferencePattern(t *testing.T) {
 }
 
 func TestParseReferenceTemplates(t *testing.T) {
-	var (
-		name  = ""
-		tests = map[string]*specs.Property{
-			"{{ input:message }}": {
-				Path: "message",
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input",
-						Path:     "message",
-					},
-				},
+	tests := map[string]specs.Template{
+		"{{ input:message }}": {
+			Reference: &specs.PropertyReference{
+				Resource: "input",
+				Path:     "message",
 			},
-			"{{ input.prop:message }}": {
-				Path: "message",
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input.prop",
-						Path:     "message",
-					},
-				},
+		},
+		"{{ input.prop:message }}": {
+			Reference: &specs.PropertyReference{
+				Resource: "input.prop",
+				Path:     "message",
 			},
-			"{{ input.prop:user-id }}": {
-				Path: "message",
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input.prop",
-						Path:     "user-id",
-					},
-				},
+		},
+		"{{ input.prop:user-id }}": {
+			Reference: &specs.PropertyReference{
+				Resource: "input.prop",
+				Path:     "user-id",
 			},
-			"{{ input:user-id }}": {
-				Path: "message",
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input",
-						Path:     "user-id",
-					},
-				},
+		},
+		"{{ input:user-id }}": {
+			Reference: &specs.PropertyReference{
+				Resource: "input",
+				Path:     "user-id",
 			},
-			"{{ input.prop:message.prop }}": {
-				Path: "message.prop",
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input.prop",
-						Path:     "message.prop",
-					},
-				},
+		},
+		"{{ input.prop:message.prop }}": {
+			Reference: &specs.PropertyReference{
+				Resource: "input.prop",
+				Path:     "message.prop",
 			},
-			"{{ input:message.prop }}": {
-				Path: "messsage.prop",
-				Template: specs.Template{
-					Reference: &specs.PropertyReference{
-						Resource: "input",
-						Path:     "message.prop",
-					},
-				},
+		},
+		"{{ input:message.prop }}": {
+			Reference: &specs.PropertyReference{
+				Resource: "input",
+				Path:     "message.prop",
 			},
-		}
-	)
+		},
+	}
 
 	for input, expected := range tests {
 		t.Run(input, func(t *testing.T) {
 			ctx := logger.WithLogger(broker.NewBackground())
-			property, err := Parse(ctx, expected.Path, name, input)
+			template, err := Parse(ctx, "", input)
 			if err != nil {
 				t.Error(err)
 			}
 
-			CompareProperties(t, property, expected)
+			CompareTemplates(t, template, expected)
 		})
 	}
 }


### PR DESCRIPTION
Increase maintainability and code clarity/responsibility: Returning specs.Property in specs/template functions does not make sense

Added some TODOs related to #194. Solving them in this PR would result in a huge amount of (unrelated) changes.

See issue #147
