### PR TITLE
fix: Cache and reuse Consul watchers

### DIFF
--- a/pkg/discovery/consul/consul.go
+++ b/pkg/discovery/consul/consul.go
@@ -8,21 +8,23 @@ import (
 )
 
 type Consul struct {
+	address  string
 	watchers map[string]*Watcher
 }
 
-// New creates a new Consul manager that keeps track of the Consul resolvers.
-func New() *Consul {
+// New creates a new Consul manager connected to the serverAddress that keeps track of the Consul resolvers.
+func New(serverAddress string) *Consul {
 	return &Consul{
+		address:  serverAddress,
 		watchers: make(map[string]*Watcher),
 	}
 }
 
 // Resolver returns a service resolver based on the continuous watcher (*Watcher type), that
 // is subscribed to all the changes related to the service name.
-// The (*Watcher).Resolve() is able to return new service address if the address has been changed.
-func (c *Consul) Resolver(address string) (discovery.Resolver, error) {
-	uri, err := url.Parse(address)
+// The (*Watcher).Resolve() is able to return new service address if the host has been changed.
+func (c *Consul) Resolver(host string) (discovery.Resolver, error) {
+	uri, err := url.Parse(host)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse the raw service address: %w", err)
 	}
@@ -40,7 +42,7 @@ func (c *Consul) Resolver(address string) (discovery.Resolver, error) {
 		return nil, fmt.Errorf("failed to build a watching plan: %w", err)
 	}
 
-	watcher := newWatcher(uri.Host, uri.Scheme, ch, plan)
+	watcher := newWatcher(c.address, uri.Scheme, ch, plan)
 	watcher.Run()
 
 	c.watchers[name] = watcher

--- a/pkg/discovery/consul/consul_test.go
+++ b/pkg/discovery/consul/consul_test.go
@@ -1,0 +1,73 @@
+package consul
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResolver(t *testing.T) {
+	t.Parallel()
+
+	// Run a mock HTTPserver to allow the watcher to connect
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Run("should return a watcher", func(t *testing.T) {
+		t.Parallel()
+		consul := New()
+
+		t.Cleanup(func() {
+			for _, watcher := range consul.watchers {
+				watcher.Stop()
+			}
+		})
+
+		watcher, err := consul.Resolver(srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if watcher == nil {
+			t.Fatal("expected to get a new watcher")
+		}
+
+		if len(consul.watchers) != 1 {
+			t.Fatal("expected to have exactly one watcher in the consul manager")
+		}
+	})
+
+	t.Run("should return a cached watcher", func(t *testing.T) {
+		t.Parallel()
+		consul := New()
+
+		t.Cleanup(func() {
+			for _, watcher := range consul.watchers {
+				watcher.Stop()
+			}
+		})
+
+		watcher, err := consul.Resolver(srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if watcher == nil {
+			t.Fatal("expected to get a new watcher")
+		}
+
+		cachedWatcher, err := consul.Resolver(srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if cachedWatcher != watcher {
+			t.Fatal("expected to get the same watcher from cache")
+		}
+
+		if len(consul.watchers) != 1 {
+			t.Fatal("expected to have exactly one watcher in the consul manager")
+		}
+	})
+}

--- a/pkg/discovery/consul/consul_test.go
+++ b/pkg/discovery/consul/consul_test.go
@@ -16,7 +16,7 @@ func TestResolver(t *testing.T) {
 
 	t.Run("should return a watcher", func(t *testing.T) {
 		t.Parallel()
-		consul := New()
+		consul := New(srv.URL)
 
 		t.Cleanup(func() {
 			for _, watcher := range consul.watchers {
@@ -40,7 +40,7 @@ func TestResolver(t *testing.T) {
 
 	t.Run("should return a cached watcher", func(t *testing.T) {
 		t.Parallel()
-		consul := New()
+		consul := New(srv.URL)
 
 		t.Cleanup(func() {
 			for _, watcher := range consul.watchers {

--- a/pkg/providers/hcl/service_discovery.go
+++ b/pkg/providers/hcl/service_discovery.go
@@ -37,7 +37,7 @@ func ParseDiscoveryClients(ctx *broker.Context, manifest Manifest) (specs.Servic
 func newServiceDiscoveryClient(dsc Discovery) (specs.ServiceDiscoveryClient, error) {
 	switch dsc.Provider {
 	case "consul":
-		return consul.New(), nil
+		return consul.New(dsc.Address), nil
 
 	default:
 		return nil, fmt.Errorf("unknown provider %q", dsc.Provider)

--- a/pkg/providers/hcl/service_discovery.go
+++ b/pkg/providers/hcl/service_discovery.go
@@ -37,9 +37,9 @@ func ParseDiscoveryClients(ctx *broker.Context, manifest Manifest) (specs.Servic
 func newServiceDiscoveryClient(dsc Discovery) (specs.ServiceDiscoveryClient, error) {
 	switch dsc.Provider {
 	case "consul":
-		return consul.New(dsc.Address), nil
+		return consul.New(), nil
 
 	default:
-		return nil, fmt.Errorf("unknown provider '%s'", dsc.Provider)
+		return nil, fmt.Errorf("unknown provider %q", dsc.Provider)
 	}
 }


### PR DESCRIPTION
Also get rid of `address` as it is not used.

Fixes #190